### PR TITLE
Flattened attributes don't have a column name

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOAttribute.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOAttribute.java
@@ -567,6 +567,9 @@ public class EOAttribute extends AbstractEOArgument<EOEntity> implements IEOAttr
 	}
 
 	public String getColumnName() {
+		if(isFlattened()) {
+			return null;
+		}
 		return (String) _prototypeValueIfNull(AbstractEOArgument.COLUMN_NAME, super.getColumnName());
 	}
 


### PR DESCRIPTION
When using flattened FK ids in vertical inheritance, Entity Modeler warns that the flattened attribute's column name is the same as the column name for the pk (assuming you name your pk's id). The reason is that the flattened attibute is returning the prototype's column name (also id in ERPrototypes) as it's own column name. Fixed the getColumnName method on EOAttribute to return null for flattened attributes.
