### PR TITLE
sort entities by name to make the ordering in the migration definite

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOEntity.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOEntity.java
@@ -75,7 +75,7 @@ import org.objectstyle.wolips.eomodeler.core.model.history.EOEntityRenamedEvent;
 import org.objectstyle.wolips.eomodeler.core.utils.BooleanUtils;
 import org.objectstyle.wolips.eomodeler.core.utils.NamingConvention;
 
-public class EOEntity extends UserInfoableEOModelObject<EOModel> implements IEOEntityRelative, ISortableEOModelObject {
+public class EOEntity extends UserInfoableEOModelObject<EOModel> implements IEOEntityRelative, ISortableEOModelObject, Comparable<EOEntity> {
 	private static final String EONEXT_PRIMARY_KEY_PROCEDURE = "EONextPrimaryKeyProcedure";
 
 	private static final String EOFETCH_WITH_PRIMARY_KEY_PROCEDURE = "EOFetchWithPrimaryKeyProcedure";
@@ -2721,5 +2721,9 @@ public class EOEntity extends UserInfoableEOModelObject<EOModel> implements IEOE
 	
 	public static void main(String[] args) {
 		System.out.println("EOEntity.main: " + NamingConvention.DEFAULT.format("NewEntity"));
+	}
+
+	public int compareTo(EOEntity otherEntity) {
+		return myName.compareTo(otherEntity.getName());
 	}
 }

--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOEntityForest.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOEntityForest.java
@@ -1,12 +1,13 @@
 package org.objectstyle.wolips.eomodeler.core.model;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * EOEntityForest represents a collection of EOEntityTreeNodes. An arbitrary
@@ -19,11 +20,11 @@ public class EOEntityForest {
 	private Map<EOEntity, EOEntityTreeNode> _nodes;
 
 	public EOEntityForest() {
-		_nodes = new HashMap<EOEntity, EOEntityTreeNode>();
+		_nodes = new TreeMap<EOEntity, EOEntityTreeNode>();
 	}
 
 	public Set<EOEntityTreeNode> getRootNodes() {
-		Set<EOEntityTreeNode> rootNodes = new HashSet<EOEntityTreeNode>();
+		Set<EOEntityTreeNode> rootNodes = new TreeSet<EOEntityTreeNode>();
 		for (EOEntityTreeNode node : _nodes.values()) {
 			if (node.isRoot()) {
 				rootNodes.add(node);
@@ -45,9 +46,11 @@ public class EOEntityForest {
 			_nodes.put(entity, node);
 
 			EOEntity parentEntity = entity.getParent();
-			EOEntityTreeNode parentNode = _nodes.get(parentEntity);
-			if (parentNode != null) {
-				parentNode.addChild(node);
+			if (parentEntity != null) {
+				EOEntityTreeNode parentNode = _nodes.get(parentEntity);
+				if (parentNode != null) {
+					parentNode.addChild(node);
+				}
 			}
 
 			Set<EOEntity> childrenEntities = entity.getChildrenEntities();

--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOEntityTreeNode.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOEntityTreeNode.java
@@ -1,8 +1,8 @@
 package org.objectstyle.wolips.eomodeler.core.model;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * EOEntityTreeNode is a data structure for representing a subtree of a set of
@@ -11,7 +11,7 @@ import java.util.Set;
  * 
  * @author mschrag
  */
-public class EOEntityTreeNode {
+public class EOEntityTreeNode implements Comparable<EOEntityTreeNode> {
 	private EOEntity _entity;
 
 	private EOEntityTreeNode _parent;
@@ -20,7 +20,7 @@ public class EOEntityTreeNode {
 
 	public EOEntityTreeNode(EOEntity entity) {
 		_entity = entity;
-		_children = new HashSet<EOEntityTreeNode>();
+		_children = new TreeSet<EOEntityTreeNode>();
 	}
 
 	public EOEntity getEntity() {
@@ -60,5 +60,9 @@ public class EOEntityTreeNode {
 
 	public String toString() {
 		return "[EOEntityNode: entity=" + _entity.getName() + "]";
+	}
+
+	public int compareTo(EOEntityTreeNode otherNode) {
+		return _entity.getName().compareTo(otherNode.getEntity().getName());
 	}
 }


### PR DESCRIPTION
Generating a migration in Entity Modeler includes the entities in an unpredictable order. This is unhandy when using cvs/svn/git/... because recreating the migration will result in a diff output reporting many changes when there aren't.
This patch will use TreeMap/TreeSet collections to sort EOEntityTreeNode and EOEntity objects by entity name.
