### PR TITLE
Migration for prototype stringArray is broken

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
@@ -46,7 +46,7 @@
 		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull});
 #elseif ($attribute.adaptorValueConversionMethodName)
 #if ($attribute.factoryMethodArgumentType.ID == "EOFactoryMethodArgumentIsNSString")
-		${migrationTableName}.newStringColumn("${attribute.columnName}", ${attribute.width}, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
+		${migrationTableName}.newStringColumn("${attribute.columnName}"#if ($attribute.width), ${attribute.width}#end, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.factoryMethodArgumentType.ID == "EOFactoryMethodArgumentIsData")
 		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull});
 #else


### PR DESCRIPTION
When using the prototype stringArray the migration code produced by entity modeler for Postgresql is: 

myTable.newStringColumn("myArrayAttribute", ${attribute.width}, false);

As for Postgresql the prototype has no external width given it should omit the width param.
