### PR TITLE
migration uses newTimestampColumn instead of newDateColumn

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
@@ -10,7 +10,7 @@
 		${migrationTableName}.newLargeStringColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.prototype.name == "ipAddress")
 		${migrationTableName}.newIpAddressColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
-#elseif ($attribute.prototype.name == "date")
+#elseif ($attribute.prototype.name == "date" || ($attribute.valueClassName == "NSCalendarDate" && $attribute.valueType == "D"))
 		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), er.extensions.foundation.ERXTimestampUtilities.timestampForString("${attribute.userInfo.default}")#end);
 #elseif ($attribute.prototype.name == "jodaLocalDate")
 		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), org.joda.time.LocalDate("${attribute.userInfo.default}")#end);


### PR DESCRIPTION
When using an attribute that has valueClassName = NSCalendarDate and valueType = D as for the date prototype from ERPrototypes the migration created by EntityModeler uses newTimestampColumn instead of newDateColumn.
