### PR TITLE
Only include *.jar files in Resources/Java on the classpath

### DIFF
--- a/woenvironment/src/java/org/objectstyle/woenvironment/frameworks/AbstractFolderFramework.java
+++ b/woenvironment/src/java/org/objectstyle/woenvironment/frameworks/AbstractFolderFramework.java
@@ -130,7 +130,7 @@ public abstract class AbstractFolderFramework extends Framework {
 			    for (String javaPath : javaPaths) {
 			      File jarFile = new File(jarFolder, javaPath);
 			      String jarFileName = jarFile.getName();
-			      if (jarFile.exists() && !isSourceJar(jarFileName)) {
+			      if (jarFile.exists() && jarFileName.toLowerCase().endsWith(".jar") && !isSourceJar(jarFileName)) {
 			        jarFiles.add(jarFile);
 			      }
 			    }


### PR DESCRIPTION
Some frameworks, in particular WOGWT include other kinds of files
in Resources/Java and these should not be treated as jars.
