### PR TITLE
output standalone="yes" when saving API file

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/api/ApiModel.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/api/ApiModel.java
@@ -296,6 +296,7 @@ public class ApiModel {
       Transformer transformer = transformerFactory.newTransformer();
       transformer.setOutputProperty(OutputKeys.INDENT, "yes");
       transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+      transformer.setOutputProperty(OutputKeys.STANDALONE, "yes");
       DOMSource domsource = new DOMSource(_document);
       StreamResult output = new StreamResult(writer);
       transformer.transform(domsource, output);


### PR DESCRIPTION
A newly created API file and the blankContent-API fallback have the declaration

<code><?xml version = "1.0" encoding = "UTF-8" standalone = "yes"?></code>

but when saving the <i>standalone = "yes"</i> part will be removed.
