### PR TITLE
Visualize deprecation status of bindings in editors

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/preferences/BindingValidationPreferencePage.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/preferences/BindingValidationPreferencePage.java
@@ -76,6 +76,7 @@ public class BindingValidationPreferencePage extends FieldEditorPreferencePage i
 		addField(new ComboFieldEditor(PreferenceConstants.WOD_API_PROBLEMS_SEVERITY_KEY, "WOD API Problems", PreferenceConstants.IGNORE_WARNING_ERROR, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceConstants.UNUSED_WOD_ELEMENT_SEVERITY_KEY, "Unused WOD Elements", PreferenceConstants.IGNORE_WARNING_ERROR, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceConstants.WOD_ERRORS_IN_HTML_SEVERITY_KEY, "WOD Errors in Template", PreferenceConstants.IGNORE_WARNING_ERROR, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceConstants.DEPRECATED_BINDING_SEVERITY_KEY, "Deprecated API in Template", PreferenceConstants.IGNORE_WARNING_ERROR, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceConstants.MISSING_COLLECTION_SEVERITY_KEY, "Missing Key on NSDictionary/NSArray", PreferenceConstants.IGNORE_WARNING_ERROR, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceConstants.MISSING_COMPONENT_SEVERITY_KEY, "Missing Key on 'extends WOComponent'", PreferenceConstants.IGNORE_WARNING_ERROR, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceConstants.MISSING_NSKVC_SEVERITY_KEY, "Missing Key on 'implements NSKeyValueCoding'", PreferenceConstants.IGNORE_WARNING_ERROR, getFieldEditorParent()));

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/preferences/PreferenceConstants.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/preferences/PreferenceConstants.java
@@ -60,6 +60,8 @@ public class PreferenceConstants {
 
 	public static final String WOD_API_PROBLEMS_SEVERITY_KEY = "WodApiProblemsSeverityKey";
 
+	public static final String DEPRECATED_BINDING_SEVERITY_KEY = "DeprecatedBindingSeverityKey";
+
 	public static final String WOD_MISSING_COMPONENT_SEVERITY_KEY = "WodProblemsSeverityKey";
 
 	public static final String WOD_ERRORS_IN_HTML_SEVERITY_KEY = "WodErrorsInHtmlSeverityKey";

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/preferences/PreferenceInitializer.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/preferences/PreferenceInitializer.java
@@ -154,6 +154,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
     prefs.setDefault(PreferenceConstants.UNUSED_WOD_ELEMENT_SEVERITY_KEY, PreferenceConstants.WARNING);
     prefs.setDefault(PreferenceConstants.WOD_MISSING_COMPONENT_SEVERITY_KEY, PreferenceConstants.ERROR);
     prefs.setDefault(PreferenceConstants.WOD_API_PROBLEMS_SEVERITY_KEY, PreferenceConstants.ERROR);
+    prefs.setDefault(PreferenceConstants.DEPRECATED_BINDING_SEVERITY_KEY, PreferenceConstants.WARNING);
     prefs.setDefault(PreferenceConstants.AT_OPERATOR_SEVERITY_KEY, PreferenceConstants.WARNING);
     prefs.setDefault(PreferenceConstants.HELPER_FUNCTION_SEVERITY_KEY, PreferenceConstants.WARNING);
     prefs.setDefault(PreferenceConstants.WELL_FORMED_TEMPLATE_KEY, PreferenceConstants.DEFAULT);

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/utils/BindingReflectionUtils.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/utils/BindingReflectionUtils.java
@@ -1,6 +1,5 @@
 package org.objectstyle.wolips.bindings.utils;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -9,7 +8,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.Flags;
@@ -540,5 +538,33 @@ public class BindingReflectionUtils {
     }
 
     return typeKeys;
+  }
+
+  /**
+   * Check if the member the given binding key points to is deprecated.
+   * 
+   * @param bindingKey the binding
+   * @return <code>true</code> if binding points to something deprecated
+   */
+  public static boolean bindingPointsToDeprecatedValue(BindingValueKey bindingKey) {
+    return memberIsDeprecated(bindingKey.getBindingMember());
+  }
+  
+  /**
+   * Check if the given member is deprecated.
+   * 
+   * @param member the member
+   * @return <code>true</code> if member is deprecated
+   */
+  public static boolean memberIsDeprecated(IMember member) {
+    boolean isDeprecated = false;
+    if (member != null) {
+      try {
+        isDeprecated = ((member.getFlags() & Flags.AccDeprecated) == Flags.AccDeprecated);
+      } catch (JavaModelException e) {
+        // ignore
+      }
+    }
+    return isDeprecated;
   }
 }

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/AbstractWodBinding.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/AbstractWodBinding.java
@@ -363,6 +363,18 @@ public abstract class AbstractWodBinding implements IWodBinding {
             // problems.add(new WodBindingValueProblem(bindingName, "The key '" + getName() + "' cannot be a constant value.", getValuePosition(), lineNumber, false));
           }
         }
+        String deprecationSeverity = Activator.getDefault().getPluginPreferences().getString(PreferenceConstants.DEPRECATED_BINDING_SEVERITY_KEY);
+        if (!PreferenceConstants.IGNORE.equals(deprecationSeverity)) {
+          BindingValueKeyPath bindingValueKeyPath = new BindingValueKeyPath(bindingValue, javaFileType, javaProject, cache);
+          if (bindingValueKeyPath.isValid() && bindingValueKeyPath.getBindingKeys() != null) {
+            for (BindingValueKey bindingKey : bindingValueKeyPath.getBindingKeys()) {
+              if (BindingReflectionUtils.bindingPointsToDeprecatedValue(bindingKey)) {
+                problems.add(new WodBindingDeprecationProblem(element, this, bindingName, "The key '" +bindingName + "' uses a value that is deprecated.", getValuePosition(), lineNumber, PreferenceConstants.WARNING.equals(deprecationSeverity)));
+                break;
+              }
+            }
+          }
+        }
 
         String invalidOGNLSeverity = Activator.getDefault().getPluginPreferences().getString(PreferenceConstants.INVALID_OGNL_SEVERITY_KEY);
         if (!PreferenceConstants.IGNORE.equals(invalidOGNLSeverity) && isOGNL()) {

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/AbstractWodElement.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/AbstractWodElement.java
@@ -273,6 +273,14 @@ public abstract class AbstractWodElement implements IWodElement, Comparable<IWod
     if (!PreferenceConstants.IGNORE.equals(unusedWodElementSeverity) && !_inline && !htmlCache.containsElementNamed(elementName)) {
       problems.add(new WodElementProblem(this, "There is no element named '" + elementName + "' in your component HTML file", getElementNamePosition(), lineNumber, PreferenceConstants.WARNING.equals(unusedWodElementSeverity)));
     }
+    
+    String deprecationSeverity = Activator.getDefault().getPluginPreferences().getString(PreferenceConstants.DEPRECATED_BINDING_SEVERITY_KEY);
+    if (!PreferenceConstants.IGNORE.equals(deprecationSeverity)) {
+      IType elementType = BindingReflectionUtils.findElementType(javaProject, elementTypeName, false, typeCache);
+      if (BindingReflectionUtils.memberIsDeprecated(elementType)) {
+        problems.add(new WodElementDeprecationProblem(this, "The component named '" + elementTypeName + "' is deprecated.", getElementTypePosition(), lineNumber, PreferenceConstants.WARNING.equals(deprecationSeverity)));
+      }
+    }
 
     Wo wo = null;
     if (!PreferenceConstants.IGNORE.equals(wodMissingComponentSeverity)) {

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/WodBindingDeprecationProblem.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/WodBindingDeprecationProblem.java
@@ -1,0 +1,15 @@
+package org.objectstyle.wolips.bindings.wod;
+
+import org.eclipse.jface.text.Position;
+import org.objectstyle.wolips.bindings.api.IApiBinding;
+
+/**
+ * Class representing a deprecated binding.
+ * 
+ * @author jw
+ */
+public class WodBindingDeprecationProblem extends WodBindingProblem {
+  public WodBindingDeprecationProblem(IWodElement element, IApiBinding binding, String bindingName, String message, Position position, int lineNumber, boolean warning) {
+    super(element, binding, bindingName, message, position, lineNumber, warning);
+  }
+}

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/WodElementDeprecationProblem.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/wod/WodElementDeprecationProblem.java
@@ -1,0 +1,14 @@
+package org.objectstyle.wolips.bindings.wod;
+
+import org.eclipse.jface.text.Position;
+
+/**
+ * Represents a Wod element that points to a deprecated element.
+ * 
+ * @author jw
+ */
+public class WodElementDeprecationProblem extends WodElementProblem {
+  public WodElementDeprecationProblem(IWodElement element, String message, Position position, int lineNumber, boolean warning) {
+    super(element, message, position, lineNumber, warning);
+  }
+}

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/InlineWodTagInfo.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/InlineWodTagInfo.java
@@ -38,6 +38,16 @@ public class InlineWodTagInfo extends TagInfo {
   public IJavaProject getJavaProject() {
     return _javaProject;
   }
+  
+  public IType getElementType() {
+    IType elementType = null;
+    try {
+      elementType = BindingReflectionUtils.findElementType(_javaProject, getExpandedElementTypeName(), false, _cache);
+    } catch (JavaModelException e) {
+      // ignore;
+    }
+    return elementType;
+  }
 
   public String getElementTypeName() {
     return _elementTypeName;

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/TemplateAssistProcessor.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/TemplateAssistProcessor.java
@@ -30,6 +30,7 @@ import org.objectstyle.wolips.bindings.wod.TagShortcut;
 import org.objectstyle.wolips.variables.BuildProperties;
 import org.objectstyle.wolips.wodclipse.core.completion.WodCompletionProposal;
 import org.objectstyle.wolips.wodclipse.core.completion.WodCompletionUtils;
+import org.objectstyle.wolips.wodclipse.core.completion.WodDeprecatedCompletionProposal;
 import org.objectstyle.wolips.wodclipse.core.completion.WodParserCache;
 import org.objectstyle.wolips.wodclipse.core.util.WodHtmlUtils;
 
@@ -221,6 +222,9 @@ public class TemplateAssistProcessor extends HTMLAssistProcessor {
           }
           AssistInfo assist = new AssistInfo(proposalString);
           assist.setOffset(dotIndex);
+          if (proposal instanceof WodDeprecatedCompletionProposal) {
+            assist.setDeprecated(true);
+          }
           attributeValuesList.add(assist);
         }
       }

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/assist/AssistInfo.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/assist/AssistInfo.java
@@ -9,7 +9,8 @@ public class AssistInfo {
 	private String displayString;
 	private String replaceString;
 	private Image image;
-  private int _offset;
+	private int _offset;
+	private boolean _deprecated;
 	
 	public AssistInfo(String displayString){
 		this.displayString = displayString;
@@ -52,8 +53,24 @@ public class AssistInfo {
   public int getOffset() {
     return _offset;
   }
-	
+
+  public void setDeprecated(boolean deprecated) {
+    _deprecated = deprecated;
+  }
+
+  public boolean getDeprecated() {
+    return _deprecated;
+  }
+
 	public ICompletionProposal toCompletionProposal(int offset, String matchString, Image defaultImage){
+		if (_deprecated) {
+			return new HTMLDeprecatedCompletionProposal(
+				getReplaceString(),
+				_offset + offset - matchString.length(), matchString.length() - _offset,
+				getReplaceString().length(),
+				getImage()==null ? defaultImage : getImage(),
+				getDisplayString(), null, null);
+		}
 		return new CompletionProposal(
 				getReplaceString(),
 				_offset + offset - matchString.length(), matchString.length() - _offset,

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/assist/HTMLAssistProcessor.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/assist/HTMLAssistProcessor.java
@@ -24,6 +24,8 @@ import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
+import org.objectstyle.wolips.bindings.utils.BindingReflectionUtils;
+import org.objectstyle.wolips.templateeditor.InlineWodTagInfo;
 import org.objectstyle.wolips.wodclipse.core.Activator;
 import org.objectstyle.wolips.wodclipse.core.preferences.PreferenceConstants;
 
@@ -379,7 +381,11 @@ public class HTMLAssistProcessor extends HTMLTemplateAssistProcessor { /*impleme
             }
           }
           try {
-            list.add(new CompletionProposal(assistKeyword, documentOffset - word.length() + 1, word.length() - 1, position, _tagImage, tagName, null, tagInfo.getDescription()));
+            if (tagInfo instanceof InlineWodTagInfo && BindingReflectionUtils.memberIsDeprecated(((InlineWodTagInfo)tagInfo).getElementType())) {
+              list.add(new HTMLDeprecatedCompletionProposal(assistKeyword, documentOffset - word.length() + 1, word.length() - 1, position, _tagImage, tagName, null, tagInfo.getDescription()));
+            } else {
+              list.add(new CompletionProposal(assistKeyword, documentOffset - word.length() + 1, word.length() - 1, position, _tagImage, tagName, null, tagInfo.getDescription()));
+            }
           }
           catch (Exception ex) {
             ex.printStackTrace();

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/assist/HTMLDeprecatedCompletionProposal.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/assist/HTMLDeprecatedCompletionProposal.java
@@ -1,0 +1,114 @@
+package tk.eclipse.plugin.htmleditor.assist;
+
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.contentassist.ICompletionProposalExtension6;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.jface.viewers.StyledString.Styler;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.TextStyle;
+
+/**
+ * Represents a completion proposal for the HTML editor that is deprecated. This should have been a
+ * subclass of {@link CompletionProposal} but unfortunately that class is final.
+ * 
+ * @author jw
+ */
+public class HTMLDeprecatedCompletionProposal implements ICompletionProposal, ICompletionProposalExtension6 {
+  /** The string to be displayed in the completion proposal popup. */
+  private String fDisplayString;
+  /** The replacement string. */
+  private String fReplacementString;
+  /** The replacement offset. */
+  private int fReplacementOffset;
+  /** The replacement length. */
+  private int fReplacementLength;
+  /** The cursor position after this proposal has been applied. */
+  private int fCursorPosition;
+  /** The image to be displayed in the completion proposal popup. */
+  private Image fImage;
+  /** The context information of this proposal. */
+  private IContextInformation fContextInformation;
+  /** The additional info of this proposal. */
+  private String fAdditionalProposalInfo;
+
+  private static final StrikeThroughStyler _strikeThroughStyler = new StrikeThroughStyler();
+
+  public HTMLDeprecatedCompletionProposal(String replacementString, int replacementOffset, int replacementLength, int cursorPosition) {
+    this(replacementString, replacementOffset, replacementLength, cursorPosition, null, null, null, null);
+  }
+
+  public HTMLDeprecatedCompletionProposal(String replacementString, int replacementOffset, int replacementLength, int cursorPosition, Image image, String displayString, IContextInformation contextInformation, String additionalProposalInfo) {
+    fReplacementString= replacementString;
+    fReplacementOffset= replacementOffset;
+    fReplacementLength= replacementLength;
+    fCursorPosition= cursorPosition;
+    fImage= image;
+    fDisplayString= displayString;
+    fContextInformation= contextInformation;
+    fAdditionalProposalInfo= additionalProposalInfo;
+  }
+
+  public StyledString getStyledDisplayString() {
+    return new StyledString(getDisplayString(), _strikeThroughStyler);
+  }
+
+  /*
+   * @see ICompletionProposal#apply(IDocument)
+   */
+  public void apply(IDocument document) {
+    try {
+      document.replace(fReplacementOffset, fReplacementLength, fReplacementString);
+    } catch (BadLocationException x) {
+      // ignore
+    }
+  }
+
+  /*
+   * @see ICompletionProposal#getSelection(IDocument)
+   */
+  public Point getSelection(IDocument document) {
+    return new Point(fReplacementOffset + fCursorPosition, 0);
+  }
+
+  /*
+   * @see ICompletionProposal#getContextInformation()
+   */
+  public IContextInformation getContextInformation() {
+    return fContextInformation;
+  }
+
+  /*
+   * @see ICompletionProposal#getImage()
+   */
+  public Image getImage() {
+    return fImage;
+  }
+
+  /*
+   * @see ICompletionProposal#getDisplayString()
+   */
+  public String getDisplayString() {
+    if (fDisplayString != null)
+      return fDisplayString;
+    return fReplacementString;
+  }
+
+  /*
+   * @see ICompletionProposal#getAdditionalProposalInfo()
+   */
+  public String getAdditionalProposalInfo() {
+    return fAdditionalProposalInfo;
+  }
+
+  private static class StrikeThroughStyler extends Styler {
+    @Override
+    public void applyStyles(TextStyle textStyle) {
+      textStyle.strikeout = true;
+    }
+  }
+}

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/editors/HTMLConfiguration.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/editors/HTMLConfiguration.java
@@ -217,6 +217,8 @@ public class HTMLConfiguration extends SourceViewerConfiguration {
 			InnerCSSAssistProcessor cssProcessor = getCSSAssistProcessor();
 			_assistant.setContentAssistProcessor(cssProcessor,HTMLPartitionScanner.HTML_CSS);
 			
+			_assistant.enableColoredLabels(true);
+			
 			_assistant.install(sourceViewer);
 			
 			// ï‚äÆÇÃê›íËÇîΩâf

--- a/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/completion/WodCompletionUtils.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/completion/WodCompletionUtils.java
@@ -102,11 +102,20 @@ public class WodCompletionUtils {
           elementTypeName = BindingReflectionUtils.getShortClassName(matchingElementTypeName);
         }
         WodCompletionProposal completionProposal;
+        IType type = typeNameCollector.getTypeForClassName(matchingElementTypeName);
         if (WodCompletionUtils.shouldSmartInsert() && guessed) {
-          completionProposal = new WodCompletionProposal(token, tokenOffset, offset, elementTypeName + " {\n\t\n}", elementTypeName, elementTypeName.length() + 4);
+          if (BindingReflectionUtils.memberIsDeprecated(type)) {
+            completionProposal = new WodDeprecatedCompletionProposal(token, tokenOffset, offset, elementTypeName + " {\n\t\n}", elementTypeName, elementTypeName.length() + 4);
+          } else {
+            completionProposal = new WodCompletionProposal(token, tokenOffset, offset, elementTypeName + " {\n\t\n}", elementTypeName, elementTypeName.length() + 4);
+          }
         }
         else {
-          completionProposal = new WodCompletionProposal(token, tokenOffset, offset, elementTypeName);
+          if (BindingReflectionUtils.memberIsDeprecated(type)) {
+            completionProposal = new WodDeprecatedCompletionProposal(token, tokenOffset, offset, elementTypeName);
+          } else {
+            completionProposal = new WodCompletionProposal(token, tokenOffset, offset, elementTypeName);
+          }
         }
         completionProposalsSet.add(completionProposal);
       }
@@ -193,9 +202,13 @@ public class WodCompletionUtils {
     Iterator<BindingValueKey> bindingKeysIter = BindingReflectionUtils.filterSystemBindingValueKeys(bindingKeys, showUsefulSystemBindings).iterator();
     while (bindingKeysIter.hasNext()) {
       BindingValueKey bindingKey = bindingKeysIter.next();
-      WodCompletionProposal completionProposal = new WodCompletionProposal(token, tokenOffset, offset, bindingKey.getBindingName());
+      WodCompletionProposal completionProposal;
+      if (BindingReflectionUtils.bindingPointsToDeprecatedValue(bindingKey)) {
+    	  completionProposal = new WodDeprecatedCompletionProposal(token, tokenOffset, offset, bindingKey.getBindingName());
+      } else {
+    	  completionProposal = new WodCompletionProposal(token, tokenOffset, offset, bindingKey.getBindingName());
+      }
       completionProposalsSet.add(completionProposal);
     }
   }
-
 }

--- a/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/completion/WodDeprecatedCompletionProposal.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/completion/WodDeprecatedCompletionProposal.java
@@ -1,0 +1,42 @@
+package org.objectstyle.wolips.wodclipse.core.completion;
+
+import org.eclipse.jface.text.contentassist.ICompletionProposalExtension6;
+import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.jface.viewers.StyledString.Styler;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.TextStyle;
+
+/**
+ * A subtype of the normal completion proposal item that will style its displayed string to
+ * have a strikeout to show that this points to something deprecated.
+ * 
+ * @author jw
+ */
+public class WodDeprecatedCompletionProposal extends WodCompletionProposal implements ICompletionProposalExtension6 {
+  private static final StrikeThroughStyler _strikeThroughStyler = new StrikeThroughStyler();
+
+  public WodDeprecatedCompletionProposal(String token, int replacementOffset, int offset, String replacementString) {
+    super(token, replacementOffset, offset, replacementString);
+  }
+
+  public WodDeprecatedCompletionProposal(String token, int replacementOffset, int offset, String replacementString, String displayString, int cursorPosition) {
+    super(token, replacementOffset, offset, replacementString, displayString, cursorPosition);
+  }
+
+  public WodDeprecatedCompletionProposal(String token, int replacementOffset, int replacementLength, int offset, String replacementString, String displayString, int cursorPosition, Image image) {
+      super(token, replacementOffset, replacementLength, offset, replacementString, displayString, cursorPosition, image);
+  }
+
+  /*
+   * @see ICompletionProposalExtension6#getStyledDisplayString()
+   */
+  public StyledString getStyledDisplayString() {
+    return new StyledString(getDisplayString(), _strikeThroughStyler);
+  }
+
+  private static class StrikeThroughStyler extends Styler {
+    public void applyStyles(TextStyle textStyle) {
+      textStyle.strikeout = true;
+    }
+  }
+}

--- a/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/validation/InlineWodProblem.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/validation/InlineWodProblem.java
@@ -9,6 +9,7 @@ import jp.aonir.fuzzyxml.FuzzyXMLElement;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.Position;
+import org.objectstyle.wolips.bindings.wod.WodBindingDeprecationProblem;
 import org.objectstyle.wolips.bindings.wod.WodBindingNameProblem;
 import org.objectstyle.wolips.bindings.wod.WodBindingValueProblem;
 import org.objectstyle.wolips.bindings.wod.WodProblem;
@@ -76,6 +77,17 @@ public class InlineWodProblem {
               marker.setAttribute(IMarker.LINE_NUMBER, WodHtmlUtils.getLineAtOffset(_cache.getHtmlEntry().getContents(), offset));
               marker.setAttribute(IMarker.CHAR_START, _element.getOffset() + attribute.getValueDataOffset() + 1);
               marker.setAttribute(IMarker.CHAR_END, _element.getOffset() + attribute.getValueDataOffset() + 1 + attribute.getValueDataLength());
+            }
+          }
+          else if (wodProblem instanceof WodBindingDeprecationProblem) {
+            String name = ((WodBindingDeprecationProblem) wodProblem).getBindingName();
+            FuzzyXMLAttribute attribute = _element.getAttributeNode(name);
+            if (attribute != null) {
+              elementError = false;
+              int offset = _element.getOffset() + attribute.getValueDataOffset() + 1;
+              marker.setAttribute(IMarker.LINE_NUMBER, WodHtmlUtils.getLineAtOffset(_cache.getHtmlEntry().getContents(), offset));
+              marker.setAttribute(IMarker.CHAR_START, offset);
+              marker.setAttribute(IMarker.CHAR_END, offset + attribute.getValueDataLength());
             }
           }
 

--- a/wolips/core/plugins/org.objectstyle.wolips.wodclipse/java/org/objectstyle/wolips/wodclipse/editor/WodSourceViewerConfiguration.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.wodclipse/java/org/objectstyle/wolips/wodclipse/editor/WodSourceViewerConfiguration.java
@@ -114,6 +114,7 @@ public class WodSourceViewerConfiguration extends SourceViewerConfiguration {
 			myContentAssistant.setAutoActivationDelay(500);
 			myContentAssistant.enableAutoInsert(true);
 			myContentAssistant.setProposalPopupOrientation(IContentAssistant.PROPOSAL_OVERLAY);
+			myContentAssistant.enableColoredLabels(true);
 		}
 		return myContentAssistant;
 	}


### PR DESCRIPTION
This patch adds validation checks for deprecated classes/methods/variables so that the popup menus with completion proposals in the HTML and Wod editor display bindings stroked through. Additionally warning/error markers are created for deprecated elements and bindings. This can be controlled by adding a setting to the WOLips validation preference pane.