### PR TITLE
Make sure the is enough space for a minimal WOD editor to prevent a NPE

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.componenteditor/java/org/objectstyle/wolips/componenteditor/part/HtmlWodTab.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.componenteditor/java/org/objectstyle/wolips/componenteditor/part/HtmlWodTab.java
@@ -221,6 +221,10 @@ public class HtmlWodTab extends ComponentEditorTab {
 				sashWeights[sashWeightNum] = Integer.parseInt(sashWeightStrs[sashWeightNum]);
 			}
 			if (sashWeights.length == getParentSashForm().getWeights().length) {
+				if (sashWeights[1] / (float)sashWeights[0] < 0.15) {
+					sashWeights[0] = 85;
+					sashWeights[1] = 15;
+				}
 				getParentSashForm().setWeights(sashWeights);
 			}
 		}


### PR DESCRIPTION
This append when opening a component editor if the previously used one was optimized for heretic people like me not using the WOD part and prefer inline bindings.

This is a temporary patch to keep the workspace usable. Before 4.4, this was supported but I do not know how to fix it properly.