### PR TITLE
use constants ALLOWS_NULL and NOT_NULL in migrations

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOAttribute.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/java/org/objectstyle/wolips/eomodeler/core/model/EOAttribute.java
@@ -1215,6 +1215,13 @@ public class EOAttribute extends AbstractEOArgument<EOEntity> implements IEOAttr
 		return getEntity().isSingleTableInheritance() || BooleanUtils.isTrue(isAllowsNull());
 	}
 
+	private static final String SQL_ALLOWS_NULL = "ALLOWS_NULL";
+	private static final String SQL_NOT_NULL = "NOT_NULL";
+	
+	public String getSqlGenerationAllowsNullAsConstant() {
+		return getSqlGenerationAllowsNull() ? SQL_ALLOWS_NULL : SQL_NOT_NULL;
+	}
+
 	public boolean getSqlGenerationCreateProperty() {
 		return !hasDefinition() && (!isInherited() || getEntity().getSqlGenerationCreateInheritedProperties() || (isInherited() && !isFlattened() && getEntity().isVerticalInheritance()));
 	}

--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
@@ -7,48 +7,48 @@
 #foreach ($attribute in $entity.sortedAttributes)
 #if ($attribute.sqlGenerationCreateProperty)
 #if ($attribute.prototype.name == "longText")
-		${migrationTableName}.newLargeStringColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
+		${migrationTableName}.newLargeStringColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.prototype.name == "ipAddress")
-		${migrationTableName}.newIpAddressColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
+		${migrationTableName}.newIpAddressColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.prototype.name == "date" || ($attribute.valueClassName == "NSCalendarDate" && $attribute.valueType == "D"))
-		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), er.extensions.foundation.ERXTimestampUtilities.timestampForString("${attribute.userInfo.default}")#end);
+		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXTimestampUtilities.timestampForString("${attribute.userInfo.default}")#end);
 #elseif ($attribute.prototype.name == "jodaLocalDate")
-		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), org.joda.time.LocalDate("${attribute.userInfo.default}")#end);
+		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), org.joda.time.LocalDate("${attribute.userInfo.default}")#end);
 #elseif ($attribute.javaClassName == "String" && $attribute.width)
-		${migrationTableName}.newStringColumn("${attribute.columnName}", ${attribute.width}, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
+		${migrationTableName}.newStringColumn("${attribute.columnName}", ${attribute.width}, ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.javaClassName == "String")
-		${migrationTableName}.newStringColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
+		${migrationTableName}.newStringColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.javaClassName == "BigDecimal" || $attribute.javaClassName == "java.math.BigDecimal")
-		${migrationTableName}.newBigDecimalColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.scale}, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), new java.math.BigDecimal("${attribute.userInfo.default}")#end);
+		${migrationTableName}.newBigDecimalColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.scale}, ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), new java.math.BigDecimal("${attribute.userInfo.default}")#end);
 #elseif ($attribute.javaClassName == "Integer" && $attribute.precision)
-		${migrationTableName}.newIntegerColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), ${attribute.userInfo.default}#end);
+		${migrationTableName}.newIntegerColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), ${attribute.userInfo.default}#end);
 #elseif ($attribute.javaClassName == "Integer")
-		${migrationTableName}.newIntegerColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), ${attribute.userInfo.default}#end);
+		${migrationTableName}.newIntegerColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), ${attribute.userInfo.default}#end);
 #elseif ($attribute.javaClassName == "Long" && $attribute.precision)
-		${migrationTableName}.newBigIntegerColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), ${attribute.userInfo.default}L#end);
+		${migrationTableName}.newBigIntegerColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), ${attribute.userInfo.default}L#end);
 #elseif ($attribute.javaClassName == "Long")
-		${migrationTableName}.newBigIntegerColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), ${attribute.userInfo.default}L#end);
+		${migrationTableName}.newBigIntegerColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), ${attribute.userInfo.default}L#end);
 #elseif ($attribute.javaClassName == "Double")
-		${migrationTableName}.newDoubleColumn("${attribute.columnName}", 0, 0, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), ${attribute.userInfo.default}d#end);
+		${migrationTableName}.newDoubleColumn("${attribute.columnName}", 0, 0, ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), ${attribute.userInfo.default}d#end);
 #elseif ($attribute.javaClassName == "Float")
-		${migrationTableName}.newFloatColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.scale}, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), ${attribute.userInfo.default}f#end);
+		${migrationTableName}.newFloatColumn("${attribute.columnName}", ${attribute.precision}, ${attribute.scale}, ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), ${attribute.userInfo.default}f#end);
 #elseif ($attribute.javaClassName == "Boolean" && $attribute.width == 5)
-		${migrationTableName}.newBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
+		${migrationTableName}.newBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
 #elseif ($attribute.javaClassName == "Boolean" && $attribute.externalType == "bool")
-		${migrationTableName}.newFlagBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
+		${migrationTableName}.newFlagBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
 #elseif ($attribute.javaClassName == "Boolean")
-		${migrationTableName}.newIntBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
+		${migrationTableName}.newIntBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
 #elseif ($attribute.javaClassName == "NSTimestamp")
-		${migrationTableName}.newTimestampColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), er.extensions.foundation.ERXTimestampUtilities.timestampForString("${attribute.userInfo.default}")#end);
+		${migrationTableName}.newTimestampColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXTimestampUtilities.timestampForString("${attribute.userInfo.default}")#end);
 #elseif ($attribute.javaClassName == "NSData")
-		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull});
+		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant});
 #elseif ($attribute.javaClassName == "ERXMutableDictionary" || $attribute.javaClassName == "er.extensions.foundation.ERXMutableDictionary")
-		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull});
+		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant});
 #elseif ($attribute.adaptorValueConversionMethodName)
 #if ($attribute.factoryMethodArgumentType.ID == "EOFactoryMethodArgumentIsNSString")
-		${migrationTableName}.newStringColumn("${attribute.columnName}"#if ($attribute.width), ${attribute.width}#end, ${attribute.sqlGenerationAllowsNull}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
+		${migrationTableName}.newStringColumn("${attribute.columnName}"#if ($attribute.width), ${attribute.width}#end, ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.factoryMethodArgumentType.ID == "EOFactoryMethodArgumentIsData")
-		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNull});
+		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant});
 #else
 		FIX // Unable to create a migration for ${attribute.name} (Java Class Name: ${attribute.javaClassName}) with the factoryMethodArgumentType ${attribute.factoryMethodArgumentType.ID}
 #end


### PR DESCRIPTION
The class Migration defines two constants ALLOWS_NULL and NOT_NULL to make the creation of table columns more readable. This patch replaces the former true/false parameters with those constants.