### PR TITLE
Eclipse 4.5 (Mars) compatibility: UI startup deprecation fix

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.pbserver/java/org/objectstyle/wolips/pbserver/PBServerPlugin.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.pbserver/java/org/objectstyle/wolips/pbserver/PBServerPlugin.java
@@ -43,11 +43,8 @@
  */
 package org.objectstyle.wolips.pbserver;
 
-import java.io.IOException;
-
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.ui.IStartup;
 import org.objectstyle.wolips.pbserver.preferences.PreferenceConstants;
 import org.objectstyle.wolips.preferences.PreferencesPlugin;
 import org.osgi.framework.BundleContext;
@@ -55,12 +52,10 @@ import org.osgi.framework.BundleContext;
 /**
  * @author mike
  */
-public class PBServerPlugin extends Plugin implements IStartup {
+public class PBServerPlugin extends Plugin {
 
 	// The shared instance.
 	private static PBServerPlugin plugin;
-
-	private PBServer myServer;
 
 	/**
 	 * The constructor.
@@ -93,18 +88,5 @@ public class PBServerPlugin extends Plugin implements IStartup {
 	 */
 	public static PBServerPlugin getDefault() {
 		return plugin;
-	}
-
-	public void earlyStartup() {
-		IPreferenceStore store = PreferencesPlugin.getDefault().getPreferenceStore();
-		if (store.getBoolean(PreferenceConstants.PBSERVER_ENABLED)) {
-			myServer = new PBServer();
-			try {
-				int port = store.getInt(PreferenceConstants.PBSERVER_PORT);
-				myServer.start(port);
-			} catch (IOException e) {
-				e.printStackTrace(System.out);
-			}
-		}
 	}
 }

--- a/wolips/core/plugins/org.objectstyle.wolips.pbserver/java/org/objectstyle/wolips/pbserver/PBServerStartup.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.pbserver/java/org/objectstyle/wolips/pbserver/PBServerStartup.java
@@ -1,0 +1,26 @@
+package org.objectstyle.wolips.pbserver;
+
+import java.io.IOException;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.IStartup;
+import org.objectstyle.wolips.pbserver.preferences.PreferenceConstants;
+import org.objectstyle.wolips.preferences.PreferencesPlugin;
+
+public class PBServerStartup implements IStartup {
+
+	private PBServer myServer;
+
+	public void earlyStartup() {
+		IPreferenceStore store = PreferencesPlugin.getDefault().getPreferenceStore();
+		if (store.getBoolean(PreferenceConstants.PBSERVER_ENABLED)) {
+			myServer = new PBServer();
+			try {
+				int port = store.getInt(PreferenceConstants.PBSERVER_PORT);
+				myServer.start(port);
+			} catch (IOException e) {
+				e.printStackTrace(System.out);
+			}
+		}
+	}
+}

--- a/wolips/core/plugins/org.objectstyle.wolips.pbserver/plugin.xml
+++ b/wolips/core/plugins/org.objectstyle.wolips.pbserver/plugin.xml
@@ -3,6 +3,9 @@
 <plugin>
    <extension
          point="org.eclipse.ui.startup">
+      <startup
+            class="org.objectstyle.wolips.pbserver.PBServerStartup">
+      </startup>
    </extension>
    <extension
          point="org.eclipse.ui.preferencePages">

--- a/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/Activator.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/Activator.java
@@ -1,23 +1,19 @@
 package org.objectstyle.wolips.womodeler;
 
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.ui.IStartup;
 import org.objectstyle.wolips.baseforuiplugins.AbstractBaseUIActivator;
 import org.objectstyle.wolips.preferences.PreferencesPlugin;
 import org.objectstyle.wolips.womodeler.preferences.PreferenceConstants;
-import org.objectstyle.wolips.womodeler.server.Webserver;
 import org.osgi.framework.BundleContext;
 
 /**
  * The activator class controls the plug-in life cycle
  */
-public class Activator extends AbstractBaseUIActivator implements IStartup {
+public class Activator extends AbstractBaseUIActivator {
   public static final int WOMODELER_PORT = 9485;
   public static final String PLUGIN_ID = "org.objectstyle.wolips.womodeler";
 
   private static Activator _plugin;
-
-  private Webserver _server;
 
   /**
    * The constructor
@@ -28,17 +24,6 @@ public class Activator extends AbstractBaseUIActivator implements IStartup {
     IPreferenceStore store = PreferencesPlugin.getDefault().getPreferenceStore();
     store.setDefault(PreferenceConstants.WOMODELER_SERVER_PORT, Activator.WOMODELER_PORT);
     store.setDefault(PreferenceConstants.WOMODELER_SERVER_ENABLED, false);
-
-    _server = new Webserver(store.getInt(PreferenceConstants.WOMODELER_SERVER_PORT));
-    _server.addRequestHandler("/womodeler", new WOModelerRequestHandler());
-    _server.addRequestHandler("/refresh", new RefreshRequestHandler());
-    _server.addRequestHandler("/openComponent", new OpenComponentRequestHandler());
-  }
-
-  public void earlyStartup() {
-    if (PreferencesPlugin.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.WOMODELER_SERVER_ENABLED)) {
-      _server.start(true);
-    }
   }
 
   /*

--- a/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/WOModelerStartup.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/WOModelerStartup.java
@@ -1,0 +1,25 @@
+package org.objectstyle.wolips.womodeler;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.IStartup;
+import org.objectstyle.wolips.preferences.PreferencesPlugin;
+import org.objectstyle.wolips.womodeler.preferences.PreferenceConstants;
+import org.objectstyle.wolips.womodeler.server.Webserver;
+
+public class WOModelerStartup implements IStartup {
+
+	private Webserver _server;
+	
+	public void earlyStartup() {
+		IPreferenceStore store = PreferencesPlugin.getDefault().getPreferenceStore();
+		
+	    _server = new Webserver(store.getInt(PreferenceConstants.WOMODELER_SERVER_PORT));
+	    _server.addRequestHandler("/womodeler", new WOModelerRequestHandler());
+	    _server.addRequestHandler("/refresh", new RefreshRequestHandler());
+	    _server.addRequestHandler("/openComponent", new OpenComponentRequestHandler());
+		
+		if (PreferencesPlugin.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.WOMODELER_SERVER_ENABLED)) {
+			_server.start(true);
+		}
+	}
+}

--- a/wolips/core/plugins/org.objectstyle.wolips.womodeler/plugin.xml
+++ b/wolips/core/plugins/org.objectstyle.wolips.womodeler/plugin.xml
@@ -3,6 +3,9 @@
 <plugin>
    <extension
          point="org.eclipse.ui.startup">
+      <startup
+            class="org.objectstyle.wolips.womodeler.WOModelerStartup">
+      </startup>
    </extension>
    <extension
          point="org.eclipse.ui.preferencePages">


### PR DESCRIPTION
In eclipse 4.5 there is a new deprecation warning in case of a plugin which has an extension of "org.eclipse.ui.startup" which is not configured properly. This fix will configure the affected wolips-plugins according to the documentation.

This warning is displayed because of a change in eclipse: https://bugs.eclipse.org/bugs/show_bug.cgi?id=50164

## The deprecation warnings

>The 'org.eclipse.ui.startup' extension from 'org.objectstyle.wolips.womodeler' does not provide a 'class' attribute.
>This usage is deprecated and a 'class' attribute should be provided.
>The release after Mars (4.5) will no longer support the deprecated usage!

## The documentation of the affected extension point

> This extension point is used to register plug-ins that want to be activated on startup. The class given as the attribute on the startup element must implement the interface org.eclipse.ui.IStartup. Once the workbench is started, the method earlyStartup() will be called from a separate thread. The class specified by the startup element's class attribute will be instantiated and earlyStartup() will be called on the result. Do not specify the plug-in class as the value of the class attribute, or it will be instantiated twice (once by regular plug-in activation, and once by this mechanism). If the extension does not provide a class as an attribute on the startup element, the plug-in's activator (plug-in class) must implement org.eclipse.ui.IStartup. Note that this form is deprecated and should no longer be used. Its functioning relies on the availability of the org.eclipse.core.runtime.compatibility plug-in and the org.eclipse.core.runtime.compatibility.registry fragment. Plug-ins that provide an extension to this extension point are listed in the workbench preferences and the user may disable any plug-in from early startup.
