### PR TITLE
bugfix for eclipse bug 145096 where filelocator returns broken url

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/ProjectTemplate.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/ProjectTemplate.java
@@ -3,6 +3,7 @@ package org.objectstyle.wolips.templateengine;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.URIUtil;
 import org.objectstyle.wolips.baseforplugins.util.FileUtilities;
 import org.objectstyle.wolips.core.resources.internal.types.project.ProjectPatternsets;
 import org.objectstyle.wolips.core.resources.types.project.ProjectAdapter;
@@ -328,7 +330,8 @@ public class ProjectTemplate implements Comparable<ProjectTemplate> {
 				}
 				if (urlInBundle != null) {
 					URL fileUrl = FileLocator.toFileURL(urlInBundle);
-					File baseFolder = new File(fileUrl.toURI());
+					URI fileUri = URIUtil.toURI(fileUrl);
+					File baseFolder = new File(fileUri);
 					templateBaseFolders.add(baseFolder);
 				}
 			}


### PR DESCRIPTION
**Project- and Component-Templates are not working when there is a SPACE in the path to the eclipse installation.**

There is an old eclipse-bug which results in FileLocator.toFileURL returning an broken URL when there are spaces in the path.
The eclipse bug for this problem: https://bugs.eclipse.org/bugs/show_bug.cgi?id=145096

The problem is that eclipse is using the deprecated `file.toURL()` in FileBundleEntry.getFileURL().
This method is deprecated with the message:
> Deprecated. This method does not automatically escape characters that are illegal in URLs. It is recommended that new code convert an abstract pathname into a URL by first converting it into a URI, via the toURI method, and then converting the URI into a URL via the URI.toURL method.

The correct method to use in the getFileURL-Method would have been `file.toURI().toURL()`.

As a workaround for this problem eclipse has the `URIUtil.toURI` method with the following description:
> Returns the URL as a URI. This method will handle URLs that are not properly encoded (for example they contain unencoded space characters).

This bugfix uses this URIUtil-Method to fix the problem.

**Steps to reproduce the problem**
* Create an eclipse-installation with a space in the path
* Try to create a  new component or a new project: it will fail because of the broken URL