### PR TITLE
Eclipse 4 6 compatibility

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.apieditor/java/org/objectstyle/wolips/apieditor/editor/ApiEditor.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.apieditor/java/org/objectstyle/wolips/apieditor/editor/ApiEditor.java
@@ -55,8 +55,6 @@
  */
 package org.objectstyle.wolips.apieditor.editor;
 
-import java.util.Vector;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -114,7 +112,6 @@ public class ApiEditor extends FormEditor {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	public void doSave(IProgressMonitor monitor) {
 		try {
 			this.getModel().saveChanges();
@@ -136,9 +133,9 @@ public class ApiEditor extends FormEditor {
 			throw new RuntimeException("Failed to save .api file.", t);
 		}
 		
-		for (ApiFormPage formPage : (Vector<ApiFormPage>)pages) {
-			if (formPage != null) {
-				formPage.reloadModel();
+		for (Object formPage : pages) {
+			if (formPage != null && formPage instanceof ApiFormPage) {
+				((ApiFormPage)formPage).reloadModel();
 			}
 		}
 	}

--- a/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/AbstractEngine.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/AbstractEngine.java
@@ -62,7 +62,6 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -81,7 +80,6 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
 /**
@@ -112,12 +110,6 @@ public abstract class AbstractEngine implements IRunnableWithProgress {
 			/*
 			 * initialize the engine
 			 */
-			String userHomeWOLipsPath = System.getProperty("user.home") + File.separator + "Library" + File.separator + "WOLips";
-			URL url = null;
-			url = Platform.resolve(TemplateEnginePlugin.baseURL());
-			String templatePaths = userHomeWOLipsPath + ", ";
-			Path path = new Path(url.getPath());
-			templatePaths = templatePaths + path.append("templates").toOSString();
 			this.velocityEngine.setProperty("resource.loader", "wolips");
 			this.velocityEngine.setProperty("wolips.resource.loader.class", "org.objectstyle.wolips.thirdparty.velocity.resourceloader.ResourceLoader");
 			this.velocityEngine.setProperty("wolips.resource.loader.bundle", TemplateEnginePlugin.getDefault().getBundle());

--- a/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/TemplateEngine.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/TemplateEngine.java
@@ -61,7 +61,6 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
 import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -73,9 +72,7 @@ import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.resource.loader.FileResourceLoader;
-import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
 /**
@@ -110,12 +107,6 @@ public class TemplateEngine implements IRunnableWithProgress {
 			/*
 			 * initialize the engine
 			 */
-			String userHomeWOLipsPath = System.getProperty("user.home") + File.separator + "Library" + File.separator + "WOLips";
-			URL url = FileLocator.resolve(TemplateEnginePlugin.baseURL());
-			String templatePaths = userHomeWOLipsPath + ", ";
-			Path path = new Path(url.getPath());
-			templatePaths = templatePaths + path.append("templates").toOSString();
-	
 			_velocityEngine.setProperty("resource.loader", "wolips, file");
 	
 			// _velocityEngine.setProperty("resource.loader", "wolips");

--- a/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/TemplateEnginePlugin.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.templateengine/java/org/objectstyle/wolips/templateengine/TemplateEnginePlugin.java
@@ -60,7 +60,6 @@ No other license or rights are granted by Apple, explicitly, by implication,
 by estoppel, or otherwise.  All rights reserved.*/
 package org.objectstyle.wolips.templateengine;
 
-import java.net.URL;
 import java.util.Dictionary;
 
 import org.eclipse.core.resources.IWorkspace;
@@ -153,15 +152,6 @@ public class TemplateEnginePlugin extends AbstractBaseUIActivator {
 	 */
 	public static IWorkspace getWorkspace() {
 		return ResourcesPlugin.getWorkspace();
-	}
-
-	/**
-	 * Method baseURL.
-	 *
-	 * @return URL
-	 */
-	public static URL baseURL() {
-		return TemplateEnginePlugin.getDefault().getDescriptor().getInstallURL();
 	}
 
 	/**

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/TemplateOutlinePage.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/TemplateOutlinePage.java
@@ -99,7 +99,7 @@ public class TemplateOutlinePage extends Page implements IContentOutlinePage, IH
   }
 
   protected FuzzyXMLParser createParser(IProject project) {
-    BuildProperties buildProperties = (BuildProperties)project.getAdapter(BuildProperties.class);
+    BuildProperties buildProperties = project.getAdapter(BuildProperties.class);
     FuzzyXMLParser parser = new FuzzyXMLParser(buildProperties != null ? buildProperties.isWellFormedTemplateRequired() : false, isHTML());
     return parser;
   }
@@ -175,7 +175,7 @@ public class TemplateOutlinePage extends Page implements IContentOutlinePage, IH
 
       FuzzyXMLNode selectedNode = _idToNodeMap.get(target);
       ProjectionAnnotationModel model = ((ProjectionViewer) _editor.getViewer()).getProjectionAnnotationModel();
-      ProjectionAnnotation lastAnnotation = getAnnotationForNode(selectedNode, model);
+      Annotation lastAnnotation = getAnnotationForNode(selectedNode, model);
       if (lastAnnotation != null) {
         model.collapse(lastAnnotation);
       }
@@ -193,7 +193,7 @@ public class TemplateOutlinePage extends Page implements IContentOutlinePage, IH
 
       FuzzyXMLNode selectedNode = _idToNodeMap.get(target);
       ProjectionAnnotationModel model = ((ProjectionViewer) _editor.getViewer()).getProjectionAnnotationModel();
-      ProjectionAnnotation lastAnnotation = getAnnotationForNode(selectedNode, model);
+      Annotation lastAnnotation = getAnnotationForNode(selectedNode, model);
       if (lastAnnotation != null) {
         model.expand(lastAnnotation);
       }
@@ -223,14 +223,13 @@ public class TemplateOutlinePage extends Page implements IContentOutlinePage, IH
    * @param model the annotation model
    * @return the matching annotation (or null if not found) 
    */
-  @SuppressWarnings("unchecked")
-  protected ProjectionAnnotation getAnnotationForNode(FuzzyXMLNode node, ProjectionAnnotationModel model) {
-    ProjectionAnnotation matchingAnnotation = null;
+  protected Annotation getAnnotationForNode(FuzzyXMLNode node, ProjectionAnnotationModel model) {
+	  Annotation matchingAnnotation = null;
     if (model != null) {
       int index = node.getOffset();
-      Iterator<ProjectionAnnotation> annotationsIter = model.getAnnotationIterator();
+      Iterator<Annotation> annotationsIter = model.getAnnotationIterator();
       while (annotationsIter.hasNext()) {
-        ProjectionAnnotation annotation = annotationsIter.next();
+    	  Annotation annotation = annotationsIter.next();
         if (model.getPosition(annotation).getOffset() == index) {
           matchingAnnotation = annotation;
         }
@@ -560,7 +559,7 @@ public class TemplateOutlinePage extends Page implements IContentOutlinePage, IH
       if (woTag) {
         className = className + " wo";
         try {
-          BuildProperties buildProperties = (BuildProperties)_editor.getParserCache().getProject().getAdapter(BuildProperties.class);
+          BuildProperties buildProperties = _editor.getParserCache().getProject().getAdapter(BuildProperties.class);
           wodElement = WodHtmlUtils.getWodElement(element, buildProperties, true, cache);
         }
         catch (Throwable t) {


### PR DESCRIPTION
As every year eclipse did some breaking changes to their API.

This commits should migrate the WOLips-Plugin to Eclipse 4.6 compatibility without breaking the compatibility to eclipse versions before 4.6.