### PR TITLE
readded some casts to be able to compile against eclipse 4.4

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/TemplateOutlinePage.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/org/objectstyle/wolips/templateeditor/TemplateOutlinePage.java
@@ -99,7 +99,7 @@ public class TemplateOutlinePage extends Page implements IContentOutlinePage, IH
   }
 
   protected FuzzyXMLParser createParser(IProject project) {
-    BuildProperties buildProperties = project.getAdapter(BuildProperties.class);
+    BuildProperties buildProperties = (BuildProperties)project.getAdapter(BuildProperties.class);
     FuzzyXMLParser parser = new FuzzyXMLParser(buildProperties != null ? buildProperties.isWellFormedTemplateRequired() : false, isHTML());
     return parser;
   }
@@ -559,7 +559,7 @@ public class TemplateOutlinePage extends Page implements IContentOutlinePage, IH
       if (woTag) {
         className = className + " wo";
         try {
-          BuildProperties buildProperties = _editor.getParserCache().getProject().getAdapter(BuildProperties.class);
+          BuildProperties buildProperties = (BuildProperties)_editor.getParserCache().getProject().getAdapter(BuildProperties.class);
           wodElement = WodHtmlUtils.getWodElement(element, buildProperties, true, cache);
         }
         catch (Throwable t) {


### PR DESCRIPTION
After the migration to support eclipse 4.6 unfortunately the support to compile against eclipse 4.4 was dropped.

* Readded the missing casts (The new version uses generics and the old version requires casts).

Tested compilation against eclipse versions 4.4, 4.5 and 4.6