### PR TITLE
Eclipse 4.7 compatibility

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/java/org/objectstyle/wolips/baseforplugins/util/FilesystemProject.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/java/org/objectstyle/wolips/baseforplugins/util/FilesystemProject.java
@@ -138,4 +138,8 @@ public class FilesystemProject extends FilesystemFolder implements IProject {
 	public boolean hasBuildConfig(String configName) throws CoreException {
 		throw new UnsupportedOperationException();
 	}
+
+	public void clearCachedDynamicReferences() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/wolips/core/plugins/org.objectstyle.wolips.wizards/java/org/objectstyle/wolips/wizards/NewComponentCreationPage.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.wizards/java/org/objectstyle/wolips/wizards/NewComponentCreationPage.java
@@ -751,7 +751,7 @@ public class NewComponentCreationPage extends NewTypeWizardPage {
 			if (resType == IResource.PROJECT || resType == IResource.FOLDER) {
 				IProject proj = res.getProject();
 				if (!proj.isOpen()) {
-					status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_ProjectClosed, BasicElementLabels.getPathLabel(proj.getFullPath(), false)));
+					status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_ProjectClosed, proj.getName()));
 					return status;
 				}
 				IJavaProject jproject = JavaCore.create(proj);
@@ -768,14 +768,14 @@ public class NewComponentCreationPage extends NewTypeWizardPage {
 							return status;
 						}
 						if (fragmentRoot.isArchive()) {
-							status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_ContainerIsBinary, BasicElementLabels.getPathLabel(path, false)));
+							status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_ContainerIsBinary, str));
 							return status;
 						}
 						// now throws a JavaModelException if not a source folder
 						if (fragmentRoot.getKind() == IPackageFragmentRoot.K_BINARY) {
-							status.setWarning(Messages.format(NewWizardMessages.NewContainerWizardPage_warning_inside_classfolder, BasicElementLabels.getPathLabel(path, false)));
+							status.setWarning(Messages.format(NewWizardMessages.NewContainerWizardPage_warning_inside_classfolder, str));
 						} else if (!jproject.isOnClasspath(fragmentRoot)) {
-							status.setWarning(Messages.format(NewWizardMessages.NewContainerWizardPage_warning_NotOnClassPath, BasicElementLabels.getPathLabel(path, false)));
+							status.setWarning(Messages.format(NewWizardMessages.NewContainerWizardPage_warning_NotOnClassPath, str));
 						}
 					} catch (JavaModelException e) {
 						// no problems. Just a standard components folder.
@@ -788,10 +788,10 @@ public class NewComponentCreationPage extends NewTypeWizardPage {
 				}
 				return status;
 			}
-			status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_NotAFolder, BasicElementLabels.getPathLabel(path, false)));
+			status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_NotAFolder, str));
 			return status;
 		}
-		status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_ContainerDoesNotExist, BasicElementLabels.getPathLabel(path, false)));
+		status.setError(Messages.format(NewWizardMessages.NewContainerWizardPage_error_ContainerDoesNotExist, str));
 		return status;
     }
 	


### PR DESCRIPTION
As every year eclipse did some breaking changes to their API.

This commits should migrate the WOLips-Plugin to Eclipse 4.7 compatibility without breaking the compatibility to eclipse versions before 4.7.
* Tested with Eclipse 4.7.M6

### The changes
* added required implementation of a new IProject-Method. 
    * The new method has no Override-Annotation for the purpose of backward-compatibility
* Changed Warning-Text-Generation in the "WOComponent Controller/View"-Wizard
    * it used newly restricted Eclipse-API "BasicElementLabels"
    * The new Warning-Text-Generation produces the same texts as the old method