### PR TITLE
Fix building with ant under Windows - as the paths of frameworks are …

### DIFF
--- a/woenvironment/src/java/org/objectstyle/woenvironment/env/WOVariables.java
+++ b/woenvironment/src/java/org/objectstyle/woenvironment/env/WOVariables.java
@@ -544,7 +544,7 @@ public class WOVariables {
     	if (!filepath.isAbsolute()) {
       		filepath = new File(_wolipsPropertiesFile.getParentFile(), path);
     	}
-    return filepath.toString();
+    return convertWindowsPath(filepath.toString());
   }
 
   public String getProperty(String aKey) {


### PR DESCRIPTION
I was using an old version of woproject.jar for too long.
After updating, building under Windows was broken - this PR fixes it