### PR TITLE
Fix compilation failure on woproject-ant-tasks

### DIFF
--- a/woenvironment/src/java/org/objectstyle/woenvironment/env/WOEnvironment.java
+++ b/woenvironment/src/java/org/objectstyle/woenvironment/env/WOEnvironment.java
@@ -57,8 +57,6 @@
 package org.objectstyle.woenvironment.env;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 
 /**
@@ -75,19 +73,11 @@ public final class WOEnvironment {
     this.woVariables = new WOVariables(null);
   }
   
-  public WOEnvironment(Map<Object, Object> existingProperties) {
+  public WOEnvironment(Map<?, ?> existingProperties) {
     this.woVariables = new WOVariables(existingProperties);
   }
   
-  public WOEnvironment(Hashtable<String, Object> existingProperties) {
-    Map<Object, Object> propertiesMap = new HashMap<Object, Object>();
-    for (String key : existingProperties.keySet()) {
-      propertiesMap.put(key, existingProperties.get(key));
-    }
-    this.woVariables = new WOVariables(propertiesMap);
-  }
-  
-  public WOEnvironment(WOVariables variables, Map<Object, Object> existingProperties) {
+  public WOEnvironment(WOVariables variables, Map<?, ?> existingProperties) {
     this.woVariables = new WOVariables(variables, existingProperties);
   }
 

--- a/woenvironment/src/java/org/objectstyle/woenvironment/env/WOVariables.java
+++ b/woenvironment/src/java/org/objectstyle/woenvironment/env/WOVariables.java
@@ -112,11 +112,11 @@ public class WOVariables {
 
 	private File _wolipsPropertiesFile;
 
-	public WOVariables(WOVariables variables, Map<Object, Object> existingProperties) {
+	public WOVariables(WOVariables variables, Map<?, ?> existingProperties) {
 		init(variables, existingProperties);
 	}
 
-	public WOVariables(Map<Object, Object> existingProperties) {
+	public WOVariables(Map<?, ?> existingProperties) {
 		init(null, existingProperties);
 	}
 	
@@ -137,7 +137,7 @@ public class WOVariables {
 		return wolipsPropertiesFile;
 	}
 
-	public void init(WOVariables variables, Map<Object, Object> existingProperties) {
+	public void init(WOVariables variables, Map<?, ?> existingProperties) {
 		_wolipsPropertiesDefaults = new Properties();
 		
 		if (variables == null) {
@@ -248,7 +248,7 @@ public class WOVariables {
 		}
 
 		if (existingProperties != null) {
-			for (Map.Entry<Object, Object> entry : existingProperties.entrySet()) {
+			for (Map.Entry<?, ?> entry : existingProperties.entrySet()) {
 				if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
 					_wolipsProperties.setProperty((String) entry.getKey(), (String) entry.getValue());
 				}

--- a/woproject-ant-tasks/pom.xml
+++ b/woproject-ant-tasks/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
-			<version>1.7.1</version>
+			<version>1.10.3</version>
 			<exclusions>
 				<exclusion>
 					<groupId>xerces</groupId>
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant-junit</artifactId>
-			<version>1.7.1</version>
+			<version>1.10.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
While trying to release a new version of woproject-ant-tasks, I faced compilation failures on multiple classes. All of them caused by a `reference to WOEnvironment is ambiguous` error. E.g.:

```
[ERROR] .../org/objectstyle/woproject/ant/WOApplication.java:[556,21] reference to WOEnvironment is ambiguous
[ERROR]   both constructor WOEnvironment(java.util.Map<java.lang.Object,java.lang.Object>) in org.objectstyle.woenvironment.env.WOEnvironment 
    and constructor WOEnvironment(java.util.Hashtable<java.lang.String,java.lang.Object>) in org.objectstyle.woenvironment.env.WOEnvironment match
```

Java is unable to choose between `Map<Object, Object>` and `Hashtable<String, Object>` when you pass a raw `Hashtable` as a parameter. Oh, the joy of Java Generics. It always confuses me. :)

I was digging into the Git history when I found out that the `WOEnvironment` constructor receiving a `Hashtable<String, Object>` parameter was introduced to solve, guess what, a compilation failure. 
As pointed out by Pascal Robert in [this comment](https://github.com/wocommunity/wolips/pull/109#issuecomment-49562581), a `Hashtable<String, Object>` couldn't be converted to `Map<Object, Object>` using Ant version 1.9.3.

This pull request makes the constructors of `WOEnvironment` and  `WOVariables` classes more flexible by replacing the parameterized type `Map<Object, Object>` with the unbounded wildcard type `Map<?, ?>`; hence, supporting old and new versions of Ant without errors.

I've also updated the Ant dependency version to 1.10.3 when building woproject-ant-tasks with Maven.

You can find more information about the original change on this [pull request](https://github.com/wocommunity/wolips/pull/109), more specifically, on [this commit](https://github.com/wocommunity/wolips/pull/109/commits/e842d6986d9217b1e43cfe3fc87e828e43642df3).