### PR TITLE
Fix compile errors since updates to workspace mechanic in April 2014.

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectTaskScanner.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectTaskScanner.java
@@ -3,7 +3,6 @@ package org.objectstyle.wolips.mechanic;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
@@ -14,12 +13,13 @@ import java.util.regex.Pattern;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 
-import com.google.eclipse.mechanic.DirectoryIteratingTaskScanner;
 import com.google.eclipse.mechanic.IResourceTaskProvider;
 import com.google.eclipse.mechanic.IResourceTaskReference;
+import com.google.eclipse.mechanic.ListCollector;
+import com.google.eclipse.mechanic.ResourceTaskScanner;
 import com.google.eclipse.mechanic.TaskCollector;
 
-public class ImportProjectTaskScanner extends DirectoryIteratingTaskScanner {
+public class ImportProjectTaskScanner extends ResourceTaskScanner {
   private static final Logger log = Logger.getLogger(ImportProjectsTask.class.getName());
 
   public ImportProjectTaskScanner() {
@@ -29,8 +29,13 @@ public class ImportProjectTaskScanner extends DirectoryIteratingTaskScanner {
   public void scan(IResourceTaskProvider source, TaskCollector collector) {
     Pattern variablePattern = Pattern.compile("^#\\s*@(\\S+)\\s+(.*)");
     
-    for (Iterator<IResourceTaskReference> iterator = source.getTaskReferences(".proj").iterator(); iterator.hasNext();) {
-      IResourceTaskReference ref = iterator.next();
+    // based on example scanner at https://github.com/alfsch/workspacemechanic/
+    // source folder: parent/bundles/com.google.eclipse.mechanic/src/
+    // source: com/google/eclipse/mechanic/internal/PreferenceFileTaskScanner.java
+    
+    ListCollector<IResourceTaskReference> taskCollector = ListCollector.create();
+    source.collectTaskReferences(".proj", taskCollector);
+    for (IResourceTaskReference ref : taskCollector.get()) {      
    	  File projectFile = ref.asFile();
       try {
         BufferedReader br = new BufferedReader(new FileReader(projectFile));
@@ -68,7 +73,7 @@ public class ImportProjectTaskScanner extends DirectoryIteratingTaskScanner {
             }
           }
           
-          collector.add(new ImportProjectsTask(id, title, description, importPaths, reconcile));
+          collector.collect(new ImportProjectsTask(id, title, description, importPaths, reconcile));
         }
         finally {
           br.close();

--- a/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectsTask.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectsTask.java
@@ -41,7 +41,6 @@ public class ImportProjectsTask extends CompositeTask {
     _reconcileProjects = reconcileProjects;
   }
 
-  @Override
   public String getId() {
     return "ImportProjectsTask-" + _id;
   }

--- a/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectsTask.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectsTask.java
@@ -18,7 +18,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import com.google.eclipse.mechanic.CompositeTask;
 
@@ -128,9 +128,9 @@ public class ImportProjectsTask extends CompositeTask {
           for (IProjectDescription projectDescription : projectDescriptions) {
             try {
               IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectDescription.getName());
-              monitor.beginTask("Importing " + project.getName() + " ...", 100);
-              project.create(projectDescription, new SubProgressMonitor(monitor, 30));
-              project.open(IResource.BACKGROUND_REFRESH, new SubProgressMonitor(monitor, 70));
+              SubMonitor subMonitor = SubMonitor.convert(monitor, "Importing " + project.getName() + " ...", 100);
+              project.create(projectDescription, subMonitor.split(30));
+              project.open(IResource.BACKGROUND_REFRESH, subMonitor.split(70));
             }
             catch (Throwable t) {
               System.out.println("ImportProjectsTask.run: " + t.getMessage());


### PR DESCRIPTION
wolips.mechanic was based on a version of workspacemechanic prior to April 2014. Eclipse RCP 4.11 (2019-03) now includes a later version of workspacemechanic so there were compile errors in wolips.mechanic. I have fixed these compile errors in this pull request. I am not sure what the functionality was so haven't tested that. I am linking to issue #128 because @Wolfy42 said this would be a lot of work. (It did take me a while but the number of changes was quite small).