### PR TITLE
StubUtility changed packages since eclipse 4.9 (2018-09)

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.wizards/java/org/objectstyle/wolips/wizards/NewComponentCreationPage.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.wizards/java/org/objectstyle/wolips/wizards/NewComponentCreationPage.java
@@ -41,7 +41,7 @@ import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.ui.JavaPlugin;

--- a/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/refactoring/AddKeyInfo.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.wodclipse.core/java/org/objectstyle/wolips/wodclipse/core/refactoring/AddKeyInfo.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.NamingConventions;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.objectstyle.wolips.bindings.utils.BindingReflectionUtils;
 import org.objectstyle.wolips.eomodeler.core.model.EOEntity;
 import org.objectstyle.wolips.eomodeler.core.model.EOModelGroup;


### PR DESCRIPTION
Refer https://bugs.eclipse.org/bugs/show_bug.cgi?id=534221
Previous import caused compile error in eclipse rcp 4.11 and probably 4.10
Note that this change will not work in eclipse 4.9 so should only be merged in a version of wolips intended for later versions of eclipse.