### PR TITLE
Make WOLips build with Eclipse 2020-09 (4.17.0)

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -1,5 +1,5 @@
 #version
-build.version = 3.5.$Revision$
+build.version = 4.17.$Revision$
 #project directories
 project.buildscripts.dir = buildscripts
 project.lib.dir = lib
@@ -19,19 +19,19 @@ build.output.homepage.dir = temp/doc
 build.output.test.dir = temp/tests
 
 #compile options
-build.compiler = javac1.5
+build.compiler = modern
 
 compile.deprecation = on
 compile.debug = on
 compile.optimize = off
 
-compile.source = 1.5
-compile.target = 1.5
+compile.source = 11
+compile.target = 11
 #wolips compile options
-wolips.build.compiler = javac1.5
+wolips.build.compiler = modern
 
-wolips.compile.source = 1.5
-wolips.compile.target = 1.5
+wolips.compile.source = 11
+wolips.compile.target = 11
 #remove references to tests core plugin
 TestsCorePluginReferenceToReplace = <import plugin="org.objectstyle.wolips.tests.core"/>
 

--- a/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/META-INF/MANIFEST.MF
+++ b/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.objectstyle.wolips.baseforplugins,
  org.objectstyle.wolips.baseforplugins.logging,
  org.objectstyle.wolips.baseforplugins.util
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.objectstyle.wolips.baseforplugins

--- a/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/java/org/objectstyle/wolips/baseforplugins/util/FilesystemProject.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/java/org/objectstyle/wolips/baseforplugins/util/FilesystemProject.java
@@ -11,7 +11,6 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IPluginDescriptor;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.content.IContentTypeMatcher;
 
@@ -56,10 +55,6 @@ public class FilesystemProject extends FilesystemFolder implements IProject {
 	}
 
 	public IProjectNature getNature(String natureId) throws CoreException {
-		throw new UnsupportedOperationException();
-	}
-
-	public IPath getPluginWorkingLocation(IPluginDescriptor plugin) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/java/org/objectstyle/wolips/baseforplugins/util/StringUtilities.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.baseforplugins/java/org/objectstyle/wolips/baseforplugins/util/StringUtilities.java
@@ -130,14 +130,14 @@ public class StringUtilities {
 	 * @param csvString
 	 * @return ArrayList
 	 */
-	public static synchronized ArrayList arrayListFromCSV(String csvString) {
+	public static synchronized ArrayList<String> arrayListFromCSV(String csvString) {
 		if (csvString == null || csvString.length() == 0) {
-			return new ArrayList();
+			return new ArrayList<String>();
 		}
 		StringTokenizer valueTokenizer = new StringTokenizer(csvString, ",");
-		ArrayList resultList = new ArrayList(valueTokenizer.countTokens());
-		while (valueTokenizer.hasMoreElements()) {
-			resultList.add(valueTokenizer.nextElement());
+		ArrayList<String> resultList = new ArrayList<String>(valueTokenizer.countTokens());
+		while (valueTokenizer.hasMoreTokens()) {
+			resultList.add(valueTokenizer.nextToken());
 		}
 		return resultList;
 	}

--- a/wolips/core/plugins/org.objectstyle.wolips.baseforuiplugins/java/org/objectstyle/wolips/baseforuiplugins/utils/KeyComboBoxCellEditor.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.baseforuiplugins/java/org/objectstyle/wolips/baseforuiplugins/utils/KeyComboBoxCellEditor.java
@@ -51,7 +51,7 @@ package org.objectstyle.wolips.baseforuiplugins.utils;
 
 import java.text.MessageFormat;
 
-import org.eclipse.jface.util.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
 import org.eclipse.swt.SWT;

--- a/wolips/core/plugins/org.objectstyle.wolips.componenteditor/java/org/objectstyle/wolips/componenteditor/inspector/BindingsDragHandler.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.componenteditor/java/org/objectstyle/wolips/componenteditor/inspector/BindingsDragHandler.java
@@ -22,10 +22,11 @@ import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TableItem;
-import org.eclipse.ui.internal.dnd.IDropTarget2;
+//import org.eclipse.ui.internal.dnd.IDropTarget2;
 import org.objectstyle.wolips.bindings.wod.BindingValueKey;
 
-public class BindingsDragHandler implements DragSourceListener, IDropTarget2, PaintListener, DropTargetListener {
+// IDropTarget2 does not exists anymore?! (it only dragFinished(boolean)).
+public class BindingsDragHandler implements DragSourceListener, /* IDropTarget2, */ PaintListener, DropTargetListener {
 	private static final int endpointSize = 3;
 
 	private WOBrowserColumn _browserColumn;

--- a/wolips/core/plugins/org.objectstyle.wolips.launching/java/org/objectstyle/wolips/launching/ui/AbstractWOArgumentsTab.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.launching/java/org/objectstyle/wolips/launching/ui/AbstractWOArgumentsTab.java
@@ -65,7 +65,7 @@ import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
-import org.eclipse.jface.util.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;

--- a/wolips/core/plugins/org.objectstyle.wolips.mechanic/.classpath
+++ b/wolips/core/plugins/org.objectstyle.wolips.mechanic/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectTaskScanner.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectTaskScanner.java
@@ -3,7 +3,6 @@ package org.objectstyle.wolips.mechanic;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
@@ -14,12 +13,11 @@ import java.util.regex.Pattern;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 
-import com.google.eclipse.mechanic.DirectoryIteratingTaskScanner;
 import com.google.eclipse.mechanic.IResourceTaskProvider;
-import com.google.eclipse.mechanic.IResourceTaskReference;
+import com.google.eclipse.mechanic.ResourceTaskScanner;
 import com.google.eclipse.mechanic.TaskCollector;
 
-public class ImportProjectTaskScanner extends DirectoryIteratingTaskScanner {
+public class ImportProjectTaskScanner extends ResourceTaskScanner {
   private static final Logger log = Logger.getLogger(ImportProjectsTask.class.getName());
 
   public ImportProjectTaskScanner() {
@@ -27,11 +25,10 @@ public class ImportProjectTaskScanner extends DirectoryIteratingTaskScanner {
 
   @Override
   public void scan(IResourceTaskProvider source, TaskCollector collector) {
-    Pattern variablePattern = Pattern.compile("^#\\s*@(\\S+)\\s+(.*)");
+    final Pattern variablePattern = Pattern.compile("^#\\s*@(\\S+)\\s+(.*)");
     
-    for (Iterator<IResourceTaskReference> iterator = source.getTaskReferences(".proj").iterator(); iterator.hasNext();) {
-      IResourceTaskReference ref = iterator.next();
-   	  File projectFile = ref.asFile();
+    source.collectTaskReferences(".proj", ref -> {
+      File projectFile = ref.asFile();
       try {
         BufferedReader br = new BufferedReader(new FileReader(projectFile));
         try {
@@ -68,7 +65,7 @@ public class ImportProjectTaskScanner extends DirectoryIteratingTaskScanner {
             }
           }
           
-          collector.add(new ImportProjectsTask(id, title, description, importPaths, reconcile));
+          collector.collect(new ImportProjectsTask(id, title, description, importPaths, reconcile));
         }
         finally {
           br.close();
@@ -77,6 +74,6 @@ public class ImportProjectTaskScanner extends DirectoryIteratingTaskScanner {
       catch (Throwable t) {
         log.log(Level.SEVERE, "Failed to read project file '" + projectFile + "'.", t);
       }
-    }
+    });
   }
 }

--- a/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectsTask.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.mechanic/src/org/objectstyle/wolips/mechanic/ImportProjectsTask.java
@@ -41,7 +41,6 @@ public class ImportProjectsTask extends CompositeTask {
     _reconcileProjects = reconcileProjects;
   }
 
-  @Override
   public String getId() {
     return "ImportProjectsTask-" + _id;
   }

--- a/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/editors/NonRuleBasedDamagerRepairer.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.tkhtmleditor/java/tk/eclipse/plugin/htmleditor/editors/NonRuleBasedDamagerRepairer.java
@@ -10,7 +10,7 @@ import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.presentation.IPresentationDamager;
 import org.eclipse.jface.text.presentation.IPresentationRepairer;
-import org.eclipse.jface.util.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.custom.StyleRange;
 
 public class NonRuleBasedDamagerRepairer

--- a/wolips/entityModeler/.classpath
+++ b/wolips/entityModeler/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/wolips/entityModeler/.settings/org.eclipse.jdt.core.prefs
+++ b/wolips/entityModeler/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.debug.lineNumber=generate
-org.eclipse.jdt.core.compiler.debug.localVariable=generate
-org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/wolips/entityModeler/META-INF/MANIFEST.MF
+++ b/wolips/entityModeler/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: objectstyle.org
 Export-Package: entitymodeler
+Automatic-Module-Name: EntityModeler

--- a/wolips/entityModeler/java/entitymodeler/ApplicationWorkbenchAdvisor.java
+++ b/wolips/entityModeler/java/entitymodeler/ApplicationWorkbenchAdvisor.java
@@ -1,6 +1,5 @@
 package entitymodeler;
 
-import javax.inject.Inject;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -22,10 +21,13 @@ import org.eclipse.ui.ide.FileStoreEditorInput;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.objectstyle.wolips.eomodeler.EOModelerPerspectiveFactory;
 import org.objectstyle.wolips.eomodeler.editors.EOModelEditor;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
 
 public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
 	private OpenDocumentEventProcessor _openDocProcessor;
-	@Inject private EnvironmentInfo environmentInfo;
 	
 	public ApplicationWorkbenchAdvisor(OpenDocumentEventProcessor openDocProcessor) {
 		_openDocProcessor = openDocProcessor;
@@ -63,7 +65,12 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
 	public void postStartup() {
 		super.postStartup();
 		try {
+		  
+		  BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
+		  ServiceReference<EnvironmentInfo> serviceRef = bundleContext.getServiceReference(EnvironmentInfo.class);
+  	  EnvironmentInfo environmentInfo = bundleContext.getService(serviceRef);
 			String[] args = environmentInfo.getNonFrameworkArgs();
+			bundleContext.ungetService(serviceRef);
 
 			String modelPath = null;
 			boolean optionValue = false;

--- a/wolips/eomodeldoc/.classpath
+++ b/wolips/eomodeldoc/.classpath
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.eomodeler.doc"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.eomodeler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.eomodeler.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.eomodeler.factories"/>
-	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/org.eclipse.equinox.common_3.6.200.v20130402-1505.jar"/>
+	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/org.eclipse.equinox.common_3.13.0.v20200828-1034.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/wolips/veogen/.classpath
+++ b/wolips/veogen/.classpath
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.eomodeler.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.eomodeler.factories"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.eogenerator.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.thirdparty.velocity"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/org.objectstyle.wolips.thirdparty.commonscollections"/>
-	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/org.eclipse.equinox.common_3.6.100.v20120522-1841.jar"/>
+	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/org.eclipse.equinox.common_3.13.0.v20200828-1034.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
This seems to restore the EOModeler functionality  #146, but more tests are needed.
The build will only work with Java 11+, because some needed Eclipse classes have the corresponding class file version 55.
The changes to the workspace mechanic plugin are similar to PR 141.
