### PR TITLE
Support the Exclude Test Code option in WO launching configurations

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.launching/java/org/objectstyle/wolips/launching/classpath/WORuntimeClasspathProvider.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.launching/java/org/objectstyle/wolips/launching/classpath/WORuntimeClasspathProvider.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.IRuntimeClasspathEntry;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.StandardClasspathProvider;
@@ -88,10 +89,14 @@ public class WORuntimeClasspathProvider extends StandardClasspathProvider {
 	public IRuntimeClasspathEntry[] superResolveClasspath(IRuntimeClasspathEntry[] entries, ILaunchConfiguration configuration) throws CoreException {
 		// use an ordered set to avoid duplicates
 		Set<IRuntimeClasspathEntry> all = new LinkedHashSet<IRuntimeClasspathEntry>(entries.length);
+		boolean excludeTestCode = configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_EXCLUDE_TEST_CODE, false);
+		
 		for (int i = 0; i < entries.length; i++) {
 			IRuntimeClasspathEntry[] resolved = JavaRuntime.resolveRuntimeClasspathEntry(entries[i], configuration);
 			for (int j = 0; j < resolved.length; j++) {
-				all.add(resolved[j]);
+				if (!(excludeTestCode && resolved[j].getClasspathEntry().isTest())) {
+					all.add(resolved[j]);
+				}
 			}
 		}
 		return all.toArray(new IRuntimeClasspathEntry[all.size()]);


### PR DESCRIPTION
WOLips always includes test dependencies when running WOApplications inside Eclipse, which may be problematic if a project has conflicting dependencies with test and runtime scopes. This fix supports the `Exclude Test Code` option of launching configurations. When enabled, WOLips won't include test dependencies in the classpath anymore.

<img width="1154" alt="exclude-test-code" src="https://user-images.githubusercontent.com/225619/171194903-ab7fead9-1fed-49f5-8a03-3f505f82688a.png">
