### PR TITLE
Added request handler to the WOLips server for opening java files #144

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/OpenJavaFileRequestHandler.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/OpenJavaFileRequestHandler.java
@@ -1,0 +1,78 @@
+package org.objectstyle.wolips.womodeler;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.eclipse.ui.texteditor.ITextEditor;
+import org.objectstyle.wolips.womodeler.server.IRequestHandler;
+import org.objectstyle.wolips.womodeler.server.Request;
+import org.objectstyle.wolips.womodeler.server.Webserver;
+
+/**
+ * Opens a Java file in Eclipse at a given line number (intended for use with
+ * WOExceptionPage)
+ */
+
+public class OpenJavaFileRequestHandler implements IRequestHandler {
+
+	public void init(Webserver server) throws Exception {
+	}
+
+	public void handle(Request request) throws Exception {
+		final Map<String, String> params = request.getQueryParameters();
+		final String appName = params.get("app");
+		final String className = params.get("className");
+		final String lineNumber = params.get("lineNumber");
+
+		// All these parameters are required
+		Objects.requireNonNull(appName);
+		Objects.requireNonNull(className);
+		Objects.requireNonNull(lineNumber);
+
+		// Let's locate a project
+		final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(appName);
+
+		if (project != null) {
+			Display.getDefault().asyncExec(new Runnable() {
+				public void run() {
+					IJavaProject javaProject = JavaCore.create(project);
+					try {
+						IType type = javaProject.findType(className);
+						if (type != null) {
+							IEditorPart editorPart = JavaUI.openInEditor(type, true, true);
+
+							if (editorPart instanceof ITextEditor) {
+								ITextEditor editor = (ITextEditor) editorPart;
+
+								IDocumentProvider provider = editor.getDocumentProvider();
+								IDocument document = provider.getDocument(editor.getEditorInput());
+
+								try {
+									int lineStart = document.getLineOffset(Integer.parseInt(lineNumber) - 1);
+									editor.selectAndReveal(lineStart, 0);
+								} catch (BadLocationException x) {
+									// We're going to a non-existent line. Not likely as is so do nothing.
+								}
+							}
+
+						}
+					} catch (Throwable e) {
+						e.printStackTrace();
+					}
+				}
+			});
+		}
+		request.getWriter().println("ok");
+	}
+}

--- a/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/WOModelerStartup.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.womodeler/java/org/objectstyle/wolips/womodeler/WOModelerStartup.java
@@ -17,6 +17,7 @@ public class WOModelerStartup implements IStartup {
 	    _server.addRequestHandler("/womodeler", new WOModelerRequestHandler());
 	    _server.addRequestHandler("/refresh", new RefreshRequestHandler());
 	    _server.addRequestHandler("/openComponent", new OpenComponentRequestHandler());
+	    _server.addRequestHandler("/openJavaFile", new OpenJavaFileRequestHandler());
 		
 		if (PreferencesPlugin.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.WOMODELER_SERVER_ENABLED)) {
 			_server.start(true);


### PR DESCRIPTION
Adds a request handler ```/openJavaFile``` to the WOLips server. The idea is to add link to line numbers in stack traces shown in WOExceptionPage, so the relevant file/location can be opened directly in Eclipse.

The URL structure is:

```http://localhost:9485/openJavaFile?pw={pw}&app={app}className={className}&lineNumber={lineNumber}```

Where
* ```pw``` WOLips server password as set in preferences
* ```app``` The application's name (which duplicates as the eclipse project name)
* ```className``` Fully qualified name of the Java class to open
* ```lineNumber``` Line number to navigate to when the file is opened

To complete the issue, WOExceptionPage/ERXException page must also be updated to link to the relevant URLs.