### PR TITLE
Add support for generating migrations for java.time prototypes

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.core/templates/EntityMigration0.java
@@ -10,7 +10,7 @@
 		${migrationTableName}.newLargeStringColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
 #elseif ($attribute.prototype.name == "ipAddress")
 		${migrationTableName}.newIpAddressColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), "${attribute.userInfo.default}"#end);
-#elseif ($attribute.prototype.name == "date" || ($attribute.valueClassName == "NSCalendarDate" && $attribute.valueType == "D"))
+#elseif ($attribute.prototype.name == "date" || ($attribute.valueClassName == "NSCalendarDate" && $attribute.valueType == "D") || $attribute.javaClassName == "java.time.LocalDate")
 		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXTimestampUtilities.timestampForString("${attribute.userInfo.default}")#end);
 #elseif ($attribute.prototype.name == "jodaLocalDate")
 		${migrationTableName}.newDateColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), org.joda.time.LocalDate("${attribute.userInfo.default}")#end);
@@ -38,8 +38,10 @@
 		${migrationTableName}.newFlagBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
 #elseif ($attribute.javaClassName == "Boolean")
 		${migrationTableName}.newIntBooleanColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXValueUtilities.booleanValue("${attribute.userInfo.default}")#end);
-#elseif ($attribute.javaClassName == "NSTimestamp")
+#elseif ($attribute.javaClassName == "NSTimestamp" || $attribute.javaClassName == "java.time.LocalDateTime" || $attribute.javaClassName == "java.time.OffsetDateTime")
 		${migrationTableName}.newTimestampColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant}#if ($attribute.userInfo.default), er.extensions.foundation.ERXTimestampUtilities.timestampForString("${attribute.userInfo.default}")#end);
+#elseif ($attribute.javaClassName == "java.time.LocalTime")
+		${migrationTableName}.newTimeColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant});
 #elseif ($attribute.javaClassName == "NSData")
 		${migrationTableName}.newBlobColumn("${attribute.columnName}", ${attribute.sqlGenerationAllowsNullAsConstant});
 #elseif ($attribute.javaClassName == "ERXMutableDictionary" || $attribute.javaClassName == "er.extensions.foundation.ERXMutableDictionary")


### PR DESCRIPTION
This pull request introduces support for java.time migration generation in Entity Modeler. Despite java.time prototypes being supported for several years in Wonder, attempts to generate migrations for entities using these types have previously resulted in errors.

For instance, users might encounter the following error message:

![Screenshot 2024-01-31 at 20 58 20](https://github.com/wocommunity/wolips/assets/225619/7744ece6-cbbc-4871-b3ab-c2f2d4cd9540)

With this update, the Entity Modeler can now successfully generate migrations for java.time types. The migration generation will adhere to the following rules:

```
| Prototype         | New Column Method  |
|-------------------|--------------------|
| javaDateTime      | newTimestampColumn |
| javaLocalDate     | newDateColumn      |
| javaLocalDateTime | newTimestampColumn |
| javaLocalTime     | newTimeColumn      |
```

The result can be seem in the image below:

![Screenshot 2024-01-31 at 20 55 35](https://github.com/wocommunity/wolips/assets/225619/ea1b5e18-10b8-472d-8a81-23b612f60901)
