### PR TITLE
Support for Eclipse 4.31 (2024-03)

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.builder/java/org/objectstyle/wolips/builder/internal/WOIncrementalBuilder.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.builder/java/org/objectstyle/wolips/builder/internal/WOIncrementalBuilder.java
@@ -224,7 +224,7 @@ public class WOIncrementalBuilder extends AbstractIncrementalProjectBuilder {
 	protected void createInfoPlist(IContainer targetContainer) throws Exception {
 		ProjectTemplate infoPListTemplate;
 		IProject project = getProject();
-		ProjectAdapter projectAdapter = (ProjectAdapter) project.getAdapter(ProjectAdapter.class);
+		ProjectAdapter projectAdapter = project.getAdapter(ProjectAdapter.class);
 		if (projectAdapter.isFramework()) {
 			infoPListTemplate = ProjectTemplate.loadProjectTemplateNamed("MiscTemplates", "FrameworkInfoPList");
 		}

--- a/wolips/core/plugins/org.objectstyle.wolips.builder/java/org/objectstyle/wolips/builder/internal/WOIncrementalBuilder.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.builder/java/org/objectstyle/wolips/builder/internal/WOIncrementalBuilder.java
@@ -275,7 +275,10 @@ public class WOIncrementalBuilder extends AbstractIncrementalProjectBuilder {
 
 	private IJavaProject getJavaProject() {
 		try {
-			return ((IJavaProject) (getProject().getNature(JavaCore.NATURE_ID)));
+			final IProject project = getProject();
+			if (project.hasNature(JavaCore.NATURE_ID)) {
+				return JavaCore.create(getProject());
+			}
 		} catch (CoreException up) {
 			this.getLogger().log(up);
 		}

--- a/wolips/core/plugins/org.objectstyle.wolips.builder/java/org/objectstyle/wolips/builder/internal/WOIncrementalBuilder.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.builder/java/org/objectstyle/wolips/builder/internal/WOIncrementalBuilder.java
@@ -69,7 +69,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.objectstyle.wolips.baseforplugins.AbstractBaseActivator;
@@ -125,21 +125,16 @@ public class WOIncrementalBuilder extends AbstractIncrementalProjectBuilder {
 			return;
 		}
 
-		IProgressMonitor subProgressMonitor = null;
-		if (null == progressMonitor) {
-			subProgressMonitor = new NullProgressMonitor();
-		} else {
-			subProgressMonitor = new SubProgressMonitor(progressMonitor, 100 * 1000);
-		}
 		IResourceDelta delta = resourceDelta;
 		if (kind != IncrementalProjectBuilder.FULL_BUILD && kind != IncrementalProjectBuilder.CLEAN_BUILD && !projectNeedsAnUpdate(delta)) {
-			subProgressMonitor.done();
 			return;
 		}
 		getLogger().debug("<incremental build>");
-		subProgressMonitor.beginTask("building WebObjects layout ...", 100);
+		
+		final SubMonitor subProgressMonitor = SubMonitor.convert(progressMonitor, "building WebObjects layout ...", 100);
+		
 		try {
-			ProjectAdapter project = (ProjectAdapter) this.getProject().getAdapter(ProjectAdapter.class);
+			ProjectAdapter project = this.getProject().getAdapter(ProjectAdapter.class);
 			boolean fullBuild = (kind == IncrementalProjectBuilder.FULL_BUILD || kind == IncrementalProjectBuilder.CLEAN_BUILD || patternsetDeltaVisitor().isFullBuildRequired());
 			String oldPrincipalClass = getArg(args, BuilderPlugin.NS_PRINCIPAL_CLASS, "");
 			if (oldPrincipalClass.length() == 0) {

--- a/wolips/core/plugins/org.objectstyle.wolips.eomodeler.eclipse/java/org/objectstyle/wolips/eomodeler/eclipse/EclipseEOModelGroupFactory.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.eomodeler.eclipse/java/org/objectstyle/wolips/eomodeler/eclipse/EclipseEOModelGroupFactory.java
@@ -159,7 +159,7 @@ public class EclipseEOModelGroupFactory implements IEOModelGroupFactory {
 				failures.add(new EOModelVerificationFailure(null, "The dependent project '" + project.getName() + "' exists but is not open.", false));
 			} else {
 				boolean visitedProject = false;
-				boolean isJavaProject = project.getNature(JavaCore.NATURE_ID) != null;
+				boolean isJavaProject = project.hasNature(JavaCore.NATURE_ID);
 				IClasspathEntry[] classpathEntries = null;
 				if (isJavaProject) {
 					IJavaProject javaProject = JavaCore.create(project);


### PR DESCRIPTION
Building WebObject projects in Eclipse 4.31 fails with an error:
`class org.eclipse.jdt.internal.core.JavaNature cannot be cast to class org.eclipse.jdt.core.IJavaProject (org.eclipse.jdt.internal.core.JavaNature and org.eclipse.jdt.core.IJavaProject are in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @...)`

This PR resolves this error by using another way to get the IJavaProject.
It also replaces the deprecated SubProgressMonitor with a SubMonitor.