### PR TITLE
Support java records in component editor

### DIFF
--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/utils/BindingReflectionUtils.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/utils/BindingReflectionUtils.java
@@ -247,6 +247,13 @@ public class BindingReflectionUtils {
       }
     }
 
+    if( type.isRecord() ) {
+    	for (IField rc : type.getRecordComponents() ) {
+    		final BindingValueKey key = new BindingValueKey(rc.getElementName(), rc.getDeclaringType(), rc, javaProject, cache);
+    		bindingKeys.add(key);
+    	}
+    }
+
     return bindingKeys;
   }
 

--- a/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/utils/BindingReflectionUtils.java
+++ b/wolips/core/plugins/org.objectstyle.wolips.bindings/java/org/objectstyle/wolips/bindings/utils/BindingReflectionUtils.java
@@ -245,13 +245,24 @@ public class BindingReflectionUtils {
           BindingReflectionUtils.fillInBindingKeys(type, types.get(typeNum), lowercaseNameStartingWith, requireExactNameMatch, accessorsOrMutators, allowInheritanceDuplicates, javaProject, bindingKeys, cache);
         }
       }
-    }
 
-    if( type.isRecord() ) {
-    	for (IField rc : type.getRecordComponents() ) {
-    		final BindingValueKey key = new BindingValueKey(rc.getElementName(), rc.getDeclaringType(), rc, javaProject, cache);
-    		bindingKeys.add(key);
-    	}
+      // CHECKME: the fillInBindingKeys() method might possibly be a better location for this logic 
+      if( type.isRecord() ) {
+    	  for (IField rc : type.getRecordComponents() ) {
+    		  final String rcName = rc.getElementName();
+    		  
+    		  if( requireExactNameMatch ) {
+    			  if (rcName.equals(nameStartingWith)) {
+    				  final BindingValueKey key = new BindingValueKey(rcName, rc.getDeclaringType(), rc, javaProject, cache);
+    				  bindingKeys.add(key);
+    			  }	    			
+    		  }
+    		  else if (rcName.startsWith(nameStartingWith)) {
+    			  final BindingValueKey key = new BindingValueKey(rcName, rc.getDeclaringType(), rc, javaProject, cache);
+    			  bindingKeys.add(key);
+    		  }
+    	  }
+      }
     }
 
     return bindingKeys;


### PR DESCRIPTION
Quick hack to support java record components in the component editor. No idea if this is the "right way" design wise, but after using it for a day it's at least definitely an improvement over the current situation.