### PR TITLE
Updated wolips.targetplatform.target to Eclipse 2025-03

### DIFF
--- a/wolips.targetplatform/wolips.targetplatform.target
+++ b/wolips.targetplatform/wolips.targetplatform.target
@@ -9,36 +9,36 @@
 			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.egit.feature.group" version="7.1.0.202411261347-r"/>
-			<unit id="org.eclipse.jgit.feature.group" version="7.1.0.202411261347-r"/>
-			<unit id="org.eclipse.epp.package.committers.feature.feature.group" version="4.34.0.20241128-0756"/>
-			<unit id="org.eclipse.mylyn.commons.activity.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.commons.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.commons.identity.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.commons.notifications.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.commons.repositories.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.context.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.egit.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.git.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.github.feature.feature.group" version="6.6.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.ide.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.jdt.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.monitor.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.pde.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.tasks.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.team.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.versions.feature.feature.group" version="4.5.0.v20241002-1142"/>
-			<unit id="org.eclipse.mylyn.wikitext.feature.feature.group" version="4.5.0.v20241022-1702"/>
-			<unit id="org.eclipse.m2e.feature.feature.group" version="2.7.0.20241126-1642"/>
-			<unit id="org.eclipse.m2e.lemminx.feature.feature.group" version="2.0.700.20240928-0605"/>
+			<unit id="org.eclipse.egit.feature.group" version="7.2.0.202503040940-r"/>
+			<unit id="org.eclipse.jgit.feature.group" version="7.2.0.202503040940-r"/>
+			<unit id="org.eclipse.epp.package.committers.feature.feature.group" version="4.35.0.20250306-0811"/>
+			<unit id="org.eclipse.mylyn.commons.activity.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.commons.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.commons.identity.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.commons.notifications.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.commons.repositories.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.context.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.egit.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.git.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.github.feature.feature.group" version="6.7.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.ide.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.jdt.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.monitor.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.pde.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.tasks.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.team.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.versions.feature.feature.group" version="4.6.0.v20241229-1209"/>
+			<unit id="org.eclipse.mylyn.wikitext.feature.feature.group" version="4.6.0.v20250108-1719"/>
+			<unit id="org.eclipse.m2e.feature.feature.group" version="2.8.0.20250224-0720"/>
+			<unit id="org.eclipse.m2e.lemminx.feature.feature.group" version="2.6.0.20250208-1755"/>
 			<unit id="org.eclipse.m2e.logback.feature.feature.group" version="2.7.0.20241001-1350"/>
-			<unit id="org.eclipse.m2e.pde.feature.feature.group" version="2.3.200.20241003-0434"/>
+			<unit id="org.eclipse.m2e.pde.feature.feature.group" version="2.3.300.20250303-1048"/>
 			<unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.3.9.202411190713"/>
 			<unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.3.6.202409052135"/>
-			<unit id="org.eclipse.epp.mpc.feature.group" version="1.11.0.v20240709-1650"/>
-			<unit id="org.eclipse.linuxtools.docker.editor.ls.feature.feature.group" version="5.17.0.202411262017"/>
+			<unit id="org.eclipse.epp.mpc.feature.group" version="1.12.0.v20250130-1529"/>
+			<!-- <unit id="org.eclipse.linuxtools.docker.editor.ls.feature.feature.group" version="5.17.0.202411262017"/>
 			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="5.17.0.202411262017"/>
-			<unit id="org.eclipse.linuxtools.jdt.docker.launcher.feature.feature.group" version="5.17.0.202411262017"/>
+			<unit id="org.eclipse.linuxtools.jdt.docker.launcher.feature.feature.group" version="5.17.0.202411262017"/> -->
 			<unit id="org.eclipse.buildship.feature.group" version="3.1.10.v20240802-1314"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -48,7 +48,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://spotbugs.github.io/eclipse/"/>
-			<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="4.8.6.r202406180231-6cf7b2c"/>
+			<!-- <unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="4.9.3.r202503151914-1f6a719"/> -->
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
Some notes:

- I have commented the "org.eclipse.linuxtools" entries, because I didn't find them anymore.
- I have commented SpotBugs, because in Eclipse PDE I can find the new version 4.9.3, but a `mvn clean package` still fails.