### PR TITLE
Prevent an error from occurring when opening an HTML-file in the template editor

### DIFF
--- a/wolips/plugins/org.objectstyle.wolips.componenteditor/java/org/objectstyle/wolips/componenteditor/part/HtmlWodTab.java
+++ b/wolips/plugins/org.objectstyle.wolips.componenteditor/java/org/objectstyle/wolips/componenteditor/part/HtmlWodTab.java
@@ -220,7 +220,7 @@ public class HtmlWodTab extends ComponentEditorTab {
 			for (int sashWeightNum = 0; sashWeightNum < sashWeightStrs.length; sashWeightNum++) {
 				sashWeights[sashWeightNum] = Integer.parseInt(sashWeightStrs[sashWeightNum]);
 			}
-			if (sashWeights.length == getParentSashForm().getWeights().length) {
+			if (sashWeights.length > 1 && sashWeights.length == getParentSashForm().getWeights().length) {
 				if (sashWeights[1] / (float)sashWeights[0] < 0.15) {
 					sashWeights[0] = 85;
 					sashWeights[1] = 15;


### PR DESCRIPTION
Opening a regular HTML file in the template editor often failed, since the template editor tried to do some editor layout cleanup/alignment that expected a .wod editor to be present. This just disables that layout cleanup if no .wod is present (which is redundant anyway since there's nothing to align).